### PR TITLE
C10_Topology S01初翻

### DIFF
--- a/MIL/C10_Topology/C10_Topology.rst
+++ b/MIL/C10_Topology/C10_Topology.rst
@@ -2,77 +2,112 @@
 
 .. index:: topology
 
-Topology
+拓扑学
 ========
 
-Calculus is based on the concept of a function, which is used to model
-quantities that depend on one another.
-For example, it is common to study quantities that change over time.
-The notion of a *limit* is also fundamental.
-We may say that the limit of a function :math:`f(x)` is a value :math:`b`
-as :math:`x` approaches a value :math:`a`,
-or that :math:`f(x)` *converges to* :math:`b` as :math:`x` approaches :math:`a`.
-Equivalently, we may say that a :math:`f(x)` approaches :math:`b` as :math:`x`
-approaches a value :math:`a`, or that it *tends to* :math:`b`
-as :math:`x` tends to :math:`a`.
-We have already begun to consider such notions in :numref:`sequences_and_convergence`.
+.. Topology
+.. ========
 
-*Topology* is the abstract study of limits and continuity.
-Having covered the essentials of formalization in Chapters :numref:`%s <basics>`
-to :numref:`%s <structures>`,
-in this chapter, we will explain how topological notions are formalized in Mathlib.
-Not only do topological abstractions apply in much greater generality,
-but that also, somewhat paradoxically, make it easier to reason about limits
-and continuity in concrete instances.
+.. Calculus is based on the concept of a function, which is used to model
+.. quantities that depend on one another.
+.. For example, it is common to study quantities that change over time.
+.. The notion of a *limit* is also fundamental.
+.. We may say that the limit of a function :math:`f(x)` is a value :math:`b`
+.. as :math:`x` approaches a value :math:`a`,
+.. or that :math:`f(x)` *converges to* :math:`b` as :math:`x` approaches :math:`a`.
+.. Equivalently, we may say that a :math:`f(x)` approaches :math:`b` as :math:`x`
+.. approaches a value :math:`a`, or that it *tends to* :math:`b`
+.. as :math:`x` tends to :math:`a`.
+.. We have already begun to consider such notions in :numref:`sequences_and_convergence`.
 
-Topological notions build on quite a few layers of mathematical structure.
-The first layer is naive set theory,
-as described in :numref:`Chapter %s <sets_and_functions>`.
-The next layer is the theory of *filters*, which we will describe in :numref:`filters`.
-On top of that, we layer
-the theories of *topological spaces*, *metric spaces*, and a slightly more exotic
-intermediate notion called a *uniform space*.
+微积分建立在函数的概念之上，旨在对相互依赖的量进行建模。例如，研究随时间变化的量是一个常见的应用场景。
+**极限**（limit）这一概念同样基础。我们可以说，当 :math:`x` 趋近于某个值 :math:`a` 时，函数 :math:`f(x)` 的极限是一个值 :math:`b` ，或者说 :math:`f(x)` 当 :math:`x` 趋近于 :math:`a` 时 **收敛于（converges to）** :math:`b` 。
+等价地，我们可以说当 :math:`x` 趋近于某个值 :math:`a` 时，:math:`f(x)` 趋近于 :math:`b` ，或者说它当 :math:`x` 趋向于 :math:`a` 时 **趋向于（tends to）** :math:`b` 。我们在
+:numref:`sequences_and_convergence`
+中已开始考虑此类概念。
 
-Whereas previous chapters relied on mathematical notions that were likely
-familiar to you,
-the notion of a filter less well known,
-even to many working mathematicians.
-The notion is essential, however, for formalizing mathematics effectively.
-Let us explain why.
-Let ``f : ℝ → ℝ`` be any function. We can consider
-the limit of ``f x`` as ``x`` approaches some value ``x₀``,
-but we can also consider the limit of ``f x`` as ``x`` approaches infinity
-or negative infinity.
-We can moreover consider the limit of ``f x`` as ``x`` approaches ``x₀`` from
-the right, conventionally written ``x₀⁺``, or from the left,
-written  ``x₀⁻``. There are variations where ``x`` approaches ``x₀`` or ``x₀⁺``
-or ``x₀⁻`` but
-is not allowed to take on the value ``x₀`` itself.
-This results in at least eight ways that ``x`` can approach something.
-We can also restrict to rational values of ``x``
-or place other constraints on the domain, but let's stick to those 8 cases.
+.. *Topology* is the abstract study of limits and continuity.
+.. Having covered the essentials of formalization in Chapters :numref:`%s <basics>`
+.. to :numref:`%s <structures>`,
+.. in this chapter, we will explain how topological notions are formalized in Mathlib.
+.. Not only do topological abstractions apply in much greater generality,
+.. but that also, somewhat paradoxically, make it easier to reason about limits
+.. and continuity in concrete instances.
 
-We have a similar variety of options on the codomain:
-we can specify that ``f x`` approaches a value from the left or right,
-or that it approaches positive or negative infinity, and so on.
-For example, we may wish to say that ``f x`` tends to ``+∞``
-when ``x`` tends to ``x₀`` from the right without
-being equal to ``x₀``.
-This results in 64 different kinds of limit statements,
-and we haven't even begun to deal with limits of sequences,
-as we did in :numref:`sequences_and_convergence`.
+**拓扑学**是对极限和连续性的抽象研究。
+在第 :numref:`%s <basics>` 章到第 :numref:`%s <structures>` 章中，我们已经介绍了形式化的基础知识，在本章中，我们将解释在 Mathlib 中如何形式化拓扑概念。
+拓扑抽象不仅适用范围更广，而且有些矛盾的是，这也使得在具体实例中推理极限和连续性变得更加容易。
 
-The problem is compounded even further when it comes to the supporting lemmas.
-For instance, limits compose: if
-``f x`` tends to ``y₀`` when ``x`` tends to ``x₀`` and
-``g y`` tends to ``z₀`` when ``y`` tends to ``y₀`` then
-``g ∘ f x`` tends to ``z₀`` when ``x`` tends to ``x₀``.
-There are three notions of "tends to" at play here,
-each of which can be instantiated in any of the eight ways described
-in the previous paragraph.
-This results in 512 lemmas, a lot to have to add to a library!
-Informally, mathematicians generally prove two or three of these
-and simply note that the rest can be proved "in the same way."
-Formalizing mathematics requires making the relevant notion of "sameness"
-fully explicit, and that is exactly what Bourbaki's theory of filters
-manages to do.
+.. Topological notions build on quite a few layers of mathematical structure.
+.. The first layer is naive set theory,
+.. as described in :numref:`Chapter %s <sets_and_functions>`.
+.. The next layer is the theory of *filters*, which we will describe in :numref:`filters`.
+.. On top of that, we layer
+.. the theories of *topological spaces*, *metric spaces*, and a slightly more exotic
+.. intermediate notion called a *uniform space*.
+
+拓扑概念建立在多层数学结构之上。
+第一层是朴素集合论，如第 :numref:`Chapter %s <sets_and_functions>` 所述。
+接下来的一层是 **滤子** 理论，我们将在 :numref:`filters` 中进行描述。
+在此之上，我们再叠加 **拓扑空间** 、 **度量空间** 以及一种稍显奇特的中间概念—— **一致空间** 的理论。
+
+.. Whereas previous chapters relied on mathematical notions that were likely
+.. familiar to you,
+.. the notion of a filter less well known,
+.. even to many working mathematicians.
+.. The notion is essential, however, for formalizing mathematics effectively.
+.. Let us explain why.
+.. Let ``f : ℝ → ℝ`` be any function. We can consider
+.. the limit of ``f x`` as ``x`` approaches some value ``x₀``,
+.. but we can also consider the limit of ``f x`` as ``x`` approaches infinity
+.. or negative infinity.
+.. We can moreover consider the limit of ``f x`` as ``x`` approaches ``x₀`` from
+.. the right, conventionally written ``x₀⁺``, or from the left,
+.. written  ``x₀⁻``. There are variations where ``x`` approaches ``x₀`` or ``x₀⁺``
+.. or ``x₀⁻`` but
+.. is not allowed to take on the value ``x₀`` itself.
+.. This results in at least eight ways that ``x`` can approach something.
+.. We can also restrict to rational values of ``x``
+.. or place other constraints on the domain, but let's stick to those 8 cases.
+
+虽然前面的章节所依赖的数学概念您可能已经熟悉，但“滤子”这一概念对您来说可能不太熟悉，甚至对许多从事数学工作的人员来说也是如此。
+然而，这一概念对于有效地形式化数学来说是必不可少的。让我们解释一下原因。
+设 ``f : ℝ → ℝ`` 为任意函数。我们可以考虑当 ``x`` 趋近于某个值 ``x₀`` 时 ``f x`` 的极限，但也可以考虑当 ``x`` 趋近于正无穷或负无穷时 ``f x`` 的极限。此外，我们还可以考虑当 ``x`` 从右趋近于 ``x₀``（通常记为 ``x₀⁺``）或从左趋近于 ``x₀``（记为 ``x₀⁻``）时 ``f x`` 的极限。还有些变化情况是 ``x`` 趋近于 ``x₀`` 或 ``x₀⁺`` 或 ``x₀⁻``，但不允许取值为 ``x₀`` 本身。
+这导致了至少八种 ``x`` 趋近于某个值的方式。我们还可以限制 ``x`` 为有理数，或者对定义域施加其他约束，但让我们先只考虑这八种情况。
+
+.. We have a similar variety of options on the codomain:
+.. we can specify that ``f x`` approaches a value from the left or right,
+.. or that it approaches positive or negative infinity, and so on.
+.. For example, we may wish to say that ``f x`` tends to ``+∞``
+.. when ``x`` tends to ``x₀`` from the right without
+.. being equal to ``x₀``.
+.. This results in 64 different kinds of limit statements,
+.. and we haven't even begun to deal with limits of sequences,
+.. as we did in :numref:`sequences_and_convergence`.
+
+在值域方面，我们也有类似的多种选择：
+我们可以指定 ``f x`` 从左侧或右侧趋近某个值，或者趋近正无穷或负无穷等等。
+例如，我们可能希望说当 ``x`` 从右侧趋近 ``x₀`` 但不等于 ``x₀`` 时，``f x`` 趋近于 ``+∞`` 。
+这会产生 64 种不同的极限表述，而且我们甚至还没有开始处理序列的极限，就像我们在 :numref:`sequences_and_convergence` 中所做的那样。
+
+.. The problem is compounded even further when it comes to the supporting lemmas.
+.. For instance, limits compose: if
+.. ``f x`` tends to ``y₀`` when ``x`` tends to ``x₀`` and
+.. ``g y`` tends to ``z₀`` when ``y`` tends to ``y₀`` then
+.. ``g ∘ f x`` tends to ``z₀`` when ``x`` tends to ``x₀``.
+.. There are three notions of "tends to" at play here,
+.. each of which can be instantiated in any of the eight ways described
+.. in the previous paragraph.
+.. This results in 512 lemmas, a lot to have to add to a library!
+.. Informally, mathematicians generally prove two or three of these
+.. and simply note that the rest can be proved "in the same way."
+.. Formalizing mathematics requires making the relevant notion of "sameness"
+.. fully explicit, and that is exactly what Bourbaki's theory of filters
+.. manages to do.
+
+当涉及到辅助引理时，问题变得更加复杂。
+例如，极限的复合：如果当 ``x`` 趋近于 ``x₀`` 时， ``f x`` 趋近于 ``y₀``，且当 ``y`` 趋近于 ``y₀`` 时， ``g y`` 趋近于 ``z₀``，那么当 ``x`` 趋近于 ``x₀`` 时， ``g ∘ f x`` 趋近于 ``z₀``。
+这里涉及三种“趋近于”的概念，每种概念都可以按照上一段描述的八种方式中的任何一种来实例化。
+而这会产生 512 个引理，要添加到库中实在太多了！
+非正式地说，数学家通常只证明其中两三个，然后简单地指出其余的可以“以相同方式”进行证明。
+形式化数学需要明确相关“相同”的概念，而这正是布尔巴基（Bourbaki）的滤子理论所做到的。

--- a/MIL/C10_Topology/C10_Topology.rst
+++ b/MIL/C10_Topology/C10_Topology.rst
@@ -5,105 +5,30 @@
 拓扑学
 ========
 
-.. Topology
-.. ========
-
-.. Calculus is based on the concept of a function, which is used to model
-.. quantities that depend on one another.
-.. For example, it is common to study quantities that change over time.
-.. The notion of a *limit* is also fundamental.
-.. We may say that the limit of a function :math:`f(x)` is a value :math:`b`
-.. as :math:`x` approaches a value :math:`a`,
-.. or that :math:`f(x)` *converges to* :math:`b` as :math:`x` approaches :math:`a`.
-.. Equivalently, we may say that a :math:`f(x)` approaches :math:`b` as :math:`x`
-.. approaches a value :math:`a`, or that it *tends to* :math:`b`
-.. as :math:`x` tends to :math:`a`.
-.. We have already begun to consider such notions in :numref:`sequences_and_convergence`.
-
 微积分建立在函数的概念之上，旨在对相互依赖的量进行建模。例如，研究随时间变化的量是一个常见的应用场景。
 **极限**（limit）这一概念同样基础。我们可以说，当 :math:`x` 趋近于某个值 :math:`a` 时，函数 :math:`f(x)` 的极限是一个值 :math:`b` ，或者说 :math:`f(x)` 当 :math:`x` 趋近于 :math:`a` 时 **收敛于（converges to）** :math:`b` 。
 等价地，我们可以说当 :math:`x` 趋近于某个值 :math:`a` 时，:math:`f(x)` 趋近于 :math:`b` ，或者说它当 :math:`x` 趋向于 :math:`a` 时 **趋向于（tends to）** :math:`b` 。我们在
 :numref:`sequences_and_convergence`
 中已开始考虑此类概念。
 
-.. *Topology* is the abstract study of limits and continuity.
-.. Having covered the essentials of formalization in Chapters :numref:`%s <basics>`
-.. to :numref:`%s <structures>`,
-.. in this chapter, we will explain how topological notions are formalized in Mathlib.
-.. Not only do topological abstractions apply in much greater generality,
-.. but that also, somewhat paradoxically, make it easier to reason about limits
-.. and continuity in concrete instances.
-
 **拓扑学**是对极限和连续性的抽象研究。
 在第 :numref:`%s <basics>` 章到第 :numref:`%s <structures>` 章中，我们已经介绍了形式化的基础知识，在本章中，我们将解释在 Mathlib 中如何形式化拓扑概念。
 拓扑抽象不仅适用范围更广，而且有些矛盾的是，这也使得在具体实例中推理极限和连续性变得更加容易。
-
-.. Topological notions build on quite a few layers of mathematical structure.
-.. The first layer is naive set theory,
-.. as described in :numref:`Chapter %s <sets_and_functions>`.
-.. The next layer is the theory of *filters*, which we will describe in :numref:`filters`.
-.. On top of that, we layer
-.. the theories of *topological spaces*, *metric spaces*, and a slightly more exotic
-.. intermediate notion called a *uniform space*.
 
 拓扑概念建立在多层数学结构之上。
 第一层是朴素集合论，如第 :numref:`Chapter %s <sets_and_functions>` 所述。
 接下来的一层是 **滤子** 理论，我们将在 :numref:`filters` 中进行描述。
 在此之上，我们再叠加 **拓扑空间** 、 **度量空间** 以及一种稍显奇特的中间概念—— **一致空间** 的理论。
 
-.. Whereas previous chapters relied on mathematical notions that were likely
-.. familiar to you,
-.. the notion of a filter less well known,
-.. even to many working mathematicians.
-.. The notion is essential, however, for formalizing mathematics effectively.
-.. Let us explain why.
-.. Let ``f : ℝ → ℝ`` be any function. We can consider
-.. the limit of ``f x`` as ``x`` approaches some value ``x₀``,
-.. but we can also consider the limit of ``f x`` as ``x`` approaches infinity
-.. or negative infinity.
-.. We can moreover consider the limit of ``f x`` as ``x`` approaches ``x₀`` from
-.. the right, conventionally written ``x₀⁺``, or from the left,
-.. written  ``x₀⁻``. There are variations where ``x`` approaches ``x₀`` or ``x₀⁺``
-.. or ``x₀⁻`` but
-.. is not allowed to take on the value ``x₀`` itself.
-.. This results in at least eight ways that ``x`` can approach something.
-.. We can also restrict to rational values of ``x``
-.. or place other constraints on the domain, but let's stick to those 8 cases.
-
 虽然前面的章节所依赖的数学概念您可能已经熟悉，但“滤子”这一概念对您来说可能不太熟悉，甚至对许多从事数学工作的人员来说也是如此。
 然而，这一概念对于有效地形式化数学来说是必不可少的。让我们解释一下原因。
 设 ``f : ℝ → ℝ`` 为任意函数。我们可以考虑当 ``x`` 趋近于某个值 ``x₀`` 时 ``f x`` 的极限，但也可以考虑当 ``x`` 趋近于正无穷或负无穷时 ``f x`` 的极限。此外，我们还可以考虑当 ``x`` 从右趋近于 ``x₀``（通常记为 ``x₀⁺``）或从左趋近于 ``x₀``（记为 ``x₀⁻``）时 ``f x`` 的极限。还有些变化情况是 ``x`` 趋近于 ``x₀`` 或 ``x₀⁺`` 或 ``x₀⁻``，但不允许取值为 ``x₀`` 本身。
 这导致了至少八种 ``x`` 趋近于某个值的方式。我们还可以限制 ``x`` 为有理数，或者对定义域施加其他约束，但让我们先只考虑这八种情况。
 
-.. We have a similar variety of options on the codomain:
-.. we can specify that ``f x`` approaches a value from the left or right,
-.. or that it approaches positive or negative infinity, and so on.
-.. For example, we may wish to say that ``f x`` tends to ``+∞``
-.. when ``x`` tends to ``x₀`` from the right without
-.. being equal to ``x₀``.
-.. This results in 64 different kinds of limit statements,
-.. and we haven't even begun to deal with limits of sequences,
-.. as we did in :numref:`sequences_and_convergence`.
-
 在值域方面，我们也有类似的多种选择：
 我们可以指定 ``f x`` 从左侧或右侧趋近某个值，或者趋近正无穷或负无穷等等。
 例如，我们可能希望说当 ``x`` 从右侧趋近 ``x₀`` 但不等于 ``x₀`` 时，``f x`` 趋近于 ``+∞`` 。
 这会产生 64 种不同的极限表述，而且我们甚至还没有开始处理序列的极限，就像我们在 :numref:`sequences_and_convergence` 中所做的那样。
-
-.. The problem is compounded even further when it comes to the supporting lemmas.
-.. For instance, limits compose: if
-.. ``f x`` tends to ``y₀`` when ``x`` tends to ``x₀`` and
-.. ``g y`` tends to ``z₀`` when ``y`` tends to ``y₀`` then
-.. ``g ∘ f x`` tends to ``z₀`` when ``x`` tends to ``x₀``.
-.. There are three notions of "tends to" at play here,
-.. each of which can be instantiated in any of the eight ways described
-.. in the previous paragraph.
-.. This results in 512 lemmas, a lot to have to add to a library!
-.. Informally, mathematicians generally prove two or three of these
-.. and simply note that the rest can be proved "in the same way."
-.. Formalizing mathematics requires making the relevant notion of "sameness"
-.. fully explicit, and that is exactly what Bourbaki's theory of filters
-.. manages to do.
 
 当涉及到辅助引理时，问题变得更加复杂。
 例如，极限的复合：如果当 ``x`` 趋近于 ``x₀`` 时， ``f x`` 趋近于 ``y₀``，且当 ``y`` 趋近于 ``y₀`` 时， ``g y`` 趋近于 ``z₀``，那么当 ``x`` 趋近于 ``x₀`` 时， ``g ∘ f x`` 趋近于 ``z₀``。

--- a/MIL/C10_Topology/S01_Filters.lean
+++ b/MIL/C10_Topology/S01_Filters.lean
@@ -8,62 +8,28 @@ open Set Filter Topology
 
 .. _filters:
 
--- Filters
-
 滤子
 -------
 
--- A *filter* on a type ``X`` is a collection of sets of ``X`` that satisfies three
--- conditions that we will spell out below. The notion
--- supports two related ideas:
 
 类型 ``X`` 上的 **滤子** 是 ``X`` 的集合的集合，满足以下三个条件（我们将在下面详细说明）。该概念支持两个相关的想法：
 
--- * *limits*, including all the kinds of limits discussed above: finite and infinite limits of sequences, finite and infinite limits of functions at a point or at infinity, and so on.
-
 * **极限**，包括上述讨论过的各种极限：数列的有限极限和无穷极限、函数在某点或无穷远处的有限极限和无穷极限等等。
-
--- * *things happening eventually*, including things happening for large enough ``n : ℕ``, or sufficiently near a point ``x``, or for sufficiently close pairs of points, or almost everywhere in the sense of measure theory. Dually, filters can also express the idea of *things happening often*: for arbitrarily large ``n``, at a point in any neighborhood of a given point, etc.
 
 * **最终发生的事情**，包括对于足够大的自然数 ``n ： ℕ`` 发生的事情，或者在某一点 ``x`` 足够近的地方发生的事情，或者对于足够接近的点对发生的事情，或者在测度论意义上几乎处处发生的事情。对偶地，滤子也可以表达**经常发生的事情**的概念：对于任意大的 ``n`` ，在给定点的任意邻域内存在某点发生，等等。
 
--- The filters that correspond to these descriptions will be defined later in this section, but we can already name them:
-
 与这些描述相对应的滤子将在本节稍后定义，但我们现在就可以给它们命名：
-
--- * ``(atTop : Filter ℕ)``, made of sets of ``ℕ`` containing ``{n | n ≥ N}`` for some ``N``
--- * ``𝓝 x``, made of neighborhoods of ``x`` in a topological space
--- * ``𝓤 X``, made of entourages of a uniform space (uniform spaces generalize metric spaces and topological groups)
--- * ``μ.ae`` , made of sets whose complement has zero measure with respect to a measure ``μ``.
 
 * ``(atTop : Filter ℕ)``，由包含 ``{n | n ≥ N}`` 的 ``ℕ`` 的集合构成，其中 ``N`` 为某个自然数
 * ``𝓝 x``，由拓扑空间中 ``x`` 的邻域构成
 * ``𝓤 X``，由一致空间的邻域基构成（一致空间推广了度量空间和拓扑群）
 * ``μ.ae``，由相对于测度 ``μ`` 其补集测度为零的集合构成
 
--- The general definition is as follows: a filter ``F : Filter X`` is a
--- collection of sets ``F.sets : Set (Set X)`` satisfying the following:
-
 一般的定义如下：一个滤子 ``F : Filter X`` 是集合 ``F.sets : Set (Set X)`` 的一个集合，满足以下条件：
-
--- * ``F.univ_sets : univ ∈ F.sets``
--- * ``F.sets_of_superset : ∀ {U V}, U ∈ F.sets → U ⊆ V → V ∈ F.sets``
--- * ``F.inter_sets : ∀ {U V}, U ∈ F.sets → V ∈ F.sets → U ∩ V ∈ F.sets``.
 
 * ``F.univ_sets : univ ∈ F.sets``
 * ``F.sets_of_superset : ∀ {U V}, U ∈ F.sets → U ⊆ V → V ∈ F.sets``
 * ``F.inter_sets : ∀ {U V}, U ∈ F.sets → V ∈ F.sets → U ∩ V ∈ F.sets``.
-
--- The first condition says that the set of all elements of ``X`` belongs to ``F.sets``.
--- The second condition says that if ``U`` belongs to ``F.sets`` then anything
--- containing ``U`` also belongs to ``F.sets``.
--- The third condition says that ``F.sets`` is closed under finite intersections.
--- In Mathlib, a filter ``F`` is defined to be a structure bundling ``F.sets`` and its
--- three properties, but the properties carry no additional data,
--- and it is convenient to blur the distinction between ``F`` and ``F.sets``. We
--- therefore define ``U ∈ F`` to mean ``U ∈ F.sets``.
--- This explains why the word ``sets`` appears in the names of some lemmas that
--- that mention ``U ∈ F``.
 
 第一个条件表明，集合 ``X`` 的所有元素都属于 ``F.sets``。
 第二个条件表明，如果 ``U`` 属于 ``F.sets``，那么包含 ``U`` 的任何集合也属于 ``F.sets``。
@@ -72,20 +38,7 @@ open Set Filter Topology
 因此，将``U ∈ F``定义为``U ∈ F.sets``。
 这就解释了为什么在一些提及``U ∈ F``的引理名称中会出现``sets``这个词。
 
--- It may help to think of a filter as defining a notion of a "sufficiently large" set. The first
--- condition then says that ``univ`` is sufficiently large, the second one says that a set containing a sufficiently
--- large set is sufficiently large and the third one says that the intersection of two sufficiently large sets
--- is sufficiently large.
-
 可以将滤子视为定义“足够大”集合的概念。第一个条件表明``univ``是足够大的集合，第二个条件表明包含足够大集合的集合也是足够大的集合，第三个条件表明两个足够大集合的交集也是足够大的集合。
-
--- It may be even  more useful to think of a filter on a type ``X``
--- as a generalized element of ``Set X``. For instance, ``atTop`` is the
--- "set of very large numbers" and ``𝓝 x₀`` is the "set of points very close to ``x₀``."
--- One manifestation of this view is that we can associate to any ``s : Set X`` the so-called *principal filter*
--- consisting of all sets that contain ``s``.
--- This definition is already in Mathlib and has a notation ``𝓟`` (localized in the ``Filter`` namespace).
--- For the purpose of demonstration, we ask you to take this opportunity to work out the definition here.
 
 将类型``X``上的一个滤子视为``Set X``的广义元素，可能更有用。例如，``atTop`` 是“极大数的集合”，而 ``𝓝 x₀`` 是“非常接近 ``x₀`` 的点的集合”。这种观点的一种体现是，我们可以将任何 ``s ： Set X`` 与所谓的“主滤子”相关联，该主滤子由包含 ``s`` 的所有集合组成。
 此定义已在 Mathlib 中，并有一个记号 ``𝓟``（在 ``Filter`` 命名空间中本地化）。为了演示的目的，我们请您借此机会在此处推导出该定义。
@@ -109,9 +62,6 @@ example {α : Type*} (s : Set α) : Filter α :=
     inter_sets := fun hU hV ↦ subset_inter hU hV }
 
 /- TEXT:
--- For our second example, we ask you to define the filter ``atTop : Filter ℕ``.
--- (We could use any type with a preorder instead of ``ℕ``.)
-
 对于我们的第二个示例，我们请您定义滤子 ``atTop : Filter ℕ`` 。（我们也可以使用任何具有预序关系的类型来代替 ``ℕ``。）
 EXAMPLES: -/
 -- QUOTE:
@@ -140,17 +90,7 @@ example : Filter ℕ :=
       constructor <;> tauto }
 
 /- TEXT:
--- We can also directly define the filter ``𝓝 x`` of neighborhoods of any ``x : ℝ``.
--- In the real numbers, a neighborhood of ``x`` is a set containing an open interval
--- :math:`(x_0 - \varepsilon, x_0 + \varepsilon)`,
--- defined in Mathlib as ``Ioo (x₀ - ε) (x₀ + ε)``.
--- (This is notion of a neighborhood is only a special case of a more general construction in Mathlib.)
-
 我们还可以直接定义任意实数 ``x ： ℝ`` 的邻域滤子 ``𝓝 x`` 。在实数中，``x`` 的邻域是一个包含开区间 :math:`(x_0 - \varepsilon, x_0 + \varepsilon)` 的集合，在 Mathlib 中定义为 ``Ioo (x₀ - ε) (x₀ + ε)`` 。（Mathlib 中的这种邻域概念只是更一般构造的一个特例。）
-
--- With these examples, we can already define what is means for a function ``f : X → Y``
--- to converge to some ``G : Filter Y`` along some ``F : Filter X``,
--- as follows:
 
 有了这些例子，我们就可以定义函数 ``f : X → Y`` 沿着某个 ``F : Filter X`` 收敛到某个 ``G : Filter Y`` 的含义，如下所述：
 BOTH: -/
@@ -160,26 +100,7 @@ def Tendsto₁ {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :=
 -- QUOTE.
 
 /- TEXT:
--- When ``X`` is ``ℕ`` and ``Y`` is ``ℝ``, ``Tendsto₁ u atTop (𝓝 x)`` is equivalent to saying that the sequence ``u : ℕ → ℝ``
--- converges to the real number ``x``. When both ``X`` and ``Y`` are ``ℝ``, ``Tendsto f (𝓝 x₀) (𝓝 y₀)``
--- is equivalent to the familiar notion :math:`\lim_{x \to x₀} f(x) = y₀`.
--- All of the other kinds of limits mentioned in the introduction are
--- also equivalent to instances of ``Tendsto₁`` for suitable choices of filters on the source and target.
-
 当 ``X`` 为 ``ℕ`` 且 ``Y`` 为 ``ℝ`` 时，``Tendsto₁ u atTop (𝓝 x)`` 等价于说序列 ``u ： ℕ → ℝ`` 收敛于实数 ``x`` 。当 ``X`` 和 ``Y`` 均为 ``ℝ`` 时，``Tendsto f (𝓝 x₀) (𝓝 y₀)`` 等价于熟悉的概念 :math:`\lim_{x \to x₀} f(x) = y₀` 。介绍中提到的所有其他类型的极限也等价于对源和目标上适当选择的滤子的 ``Tendsto₁`` 的实例。
-
--- The notion ``Tendsto₁`` above is definitionally equivalent to the notion ``Tendsto`` that is defined in Mathlib,
--- but the latter is defined more abstractly.
--- The problem with the definition of ``Tendsto₁`` is that it exposes a quantifier and elements of ``G``,
--- and it hides the intuition that we get by viewing filters as generalized sets. We can
--- hide the quantifier ``∀ V`` and make the intuition more salient by using more algebraic and set-theoretic machinery.
--- The first ingredient is the *pushforward* operation :math:`f_*` associated to any map ``f : X → Y``,
--- denoted ``Filter.map f`` in Mathlib. Given a filter ``F`` on ``X``, ``Filter.map f F : Filter Y`` is defined so that
--- ``V ∈ Filter.map f F ↔ f ⁻¹' V ∈ F`` holds definitionally.
--- In this examples file we've opened the ``Filter`` namespace so that
--- ``Filter.map`` can be written as ``map``. This means that we can rewrite the definition of ``Tendsto`` using
--- the order relation on ``Filter Y``, which is reversed inclusion of the set of members.
--- In other words, given ``G H : Filter Y``, we have ``G ≤ H ↔ ∀ V : Set Y, V ∈ H → V ∈ G``.
 
 上述的``Tendsto₁``概念在定义上等同于在 Mathlib 中定义的``Tendsto``概念，但后者定义得更为抽象。``Tendsto₁``的定义存在的问题是它暴露了量词和``G``的元素，并且掩盖了通过将滤子视为广义集合所获得的直观理解。我们可以通过使用更多的代数和集合论工具来隐藏量词``∀ V``，并使这种直观理解更加突出。第一个要素是与任何映射``f : X → Y``相关的**前推**操作 ：math:`f_*`，在 Mathlib 中记为``Filter.map f``。给定``X``上的滤子``F``，``Filter.map f F ： Filter Y``被定义为使得``V ∈ Filter.map f F ↔ f ⁻¹' V ∈ F``成立。在这个示例文件中，我们已经打开了``Filter``命名空间，因此``Filter.map``可以写成``map``。这意味着我们可以使用``Filter Y``上的序关系来重写``Tendsto``的定义，该序关系是成员集合的反向包含关系。换句话说，给定``G H ： Filter Y``，我们有``G ≤ H ↔ ∀ V ： Set Y， V ∈ H → V ∈ G``。
 EXAMPLES: -/
@@ -193,25 +114,9 @@ example {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :
 -- QUOTE.
 
 /- TEXT:
--- It may seem that the order relation on filters is backward. But recall that we can view filters on ``X`` as
--- generalized elements of ``Set X``, via the inclusion of ``𝓟 : Set X → Filter X`` which maps any set ``s`` to the corresponding principal filter.
--- This inclusion is order preserving, so the order relation on ``Filter`` can indeed be seen as the natural inclusion relation
--- between generalized sets. In this analogy, pushforward is analogous to the direct image.
--- And, indeed, ``map f (𝓟 s) = 𝓟 (f '' s)``.
-
 可能看起来滤子上的序关系是反向的。但请回想一下，我们可以通过将任何集合 ``s`` 映射到相应的主滤子的 ``𝓟 ： Set X → Filter X`` 的包含关系，将 ``X`` 上的滤子视为 ``Set X`` 的广义元素。这种包含关系是保序的，因此 ``Filter`` 上的序关系确实可以被视为广义集合之间的自然包含关系。在这个类比中，前推类似于直接像（direct image）。而且，确实有 ``map f (𝓟 s) = 𝓟 (f '' s)``。
 
--- We can now understand intuitively why a sequence ``u : ℕ → ℝ`` converges to
--- a point ``x₀`` if and only if we have ``map u atTop ≤ 𝓝 x₀``.
--- The inequality means the "direct image under ``u``" of
--- "the set of very big natural numbers" is "included" in "the set of points very close to ``x₀``."
-
 现在我们可以直观地理解为什么一个序列 ``u ： ℕ → ℝ`` 收敛于点 ``x₀`` 当且仅当 ``map u atTop ≤ 𝓝 x₀`` 成立。这个不等式意味着在 “``u`` 作用下”的“非常大的自然数集合”的“直接像”包含在“非常接近 ``x₀`` 的点的集合”中。
-
--- As promised, the definition of ``Tendsto₂`` does not exhibit any quantifiers or sets.
--- It also leverages the algebraic properties of the pushforward operation.
--- First, each ``Filter.map f`` is monotone. And, second, ``Filter.map`` is compatible with
--- composition.
 
 正如所承诺的那样，``Tendsto₂`` 的定义中没有任何量词或集合。
 它还利用了前推操作的代数性质。
@@ -226,13 +131,6 @@ EXAMPLES: -/
 -- QUOTE.
 
 /- TEXT:
--- Together these two properties allow us to prove that limits compose, yielding in one shot all 256 variants
--- of the composition lemma described in the introduction, and lots more.
--- You can practice proving the following statement using either the definition
--- of ``Tendsto₁`` in terms of the
--- universal quantifier or the algebraic definition,
--- together with the two lemmas above.
-
 这两个性质结合起来使我们能够证明极限的复合性，从而一次性得出引言中描述的 256 种组合引理变体，以及更多。
 您可以使用``Tendsto₁``的全称量词定义或代数定义，连同上述两个引理，来练习证明以下陈述。
 EXAMPLES: -/
@@ -260,24 +158,6 @@ example {X Y Z : Type*} {F : Filter X} {G : Filter Y} {H : Filter Z} {f : X → 
   exact hV
 
 /- TEXT:
--- The pushforward construction uses a map to push filters from the map source to the map target.
--- There also a *pullback* operation, ``Filter.comap``, going in the other direction.
--- This generalizes the
--- preimage operation on sets. For any map ``f``,
--- ``Filter.map f`` and ``Filter.comap f`` form what is known as a *Galois connection*,
--- which is to say, they satisfy
-
---   ``Filter.map_le_iff_le_comap : Filter.map f F ≤ G ↔ F ≤ Filter.comap f G``
-
--- for every ``F`` and ``G``.
--- This operation could be used to provided another formulation of ``Tendsto`` that would be provably
--- (but not definitionally) equivalent to the one in Mathlib.
-
--- The ``comap`` operation can be used to restrict filters to a subtype. For instance, suppose we have ``f : ℝ → ℝ``,
--- ``x₀ : ℝ`` and ``y₀ : ℝ``, and suppose we want to state that ``f x`` approaches ``y₀`` when ``x`` approaches ``x₀`` within the rational numbers.
--- We can pull the filter ``𝓝 x₀`` back to ``ℚ`` using the coercion map
--- ``(↑) : ℚ → ℝ`` and state ``Tendsto (f ∘ (↑) : ℚ → ℝ) (comap (↑) (𝓝 x₀)) (𝓝 y₀)``.
-
 前推构造使用一个映射将滤子从映射源推送到映射目标。
 还有一个“拉回”操作，即 ``Filter.comap`` ，其方向相反。
 这推广了集合上的原像操作。对于任何映射 ``f`` ，
@@ -299,10 +179,7 @@ variable (f : ℝ → ℝ) (x₀ y₀ : ℝ)
 -- QUOTE.
 
 /- TEXT:
--- The pullback operation is also compatible with composition, but it is *contravariant*,
--- which is to say, it reverses the order of the arguments.
-
-拉回操作也与复合运算兼容，但它具有**反变性**，也就是说，它会颠倒参数的顺序。
+拉回操作也与复合运算兼容，但它具有**逆变性**，也就是说，它会颠倒参数的顺序。
 EXAMPLES: -/
 -- QUOTE:
 section
@@ -314,10 +191,6 @@ end
 -- QUOTE.
 
 /- TEXT:
--- Let's now shift attention to the plane ``ℝ × ℝ`` and try to understand how the neighborhoods of a point
--- ``(x₀, y₀)`` are related to ``𝓝 x₀`` and ``𝓝 y₀``. There is a product operation
--- ``Filter.prod : Filter X → Filter Y → Filter (X × Y)``, denoted by ``×ˢ``, which answers this question:
-
 现在让我们将注意力转向平面``ℝ × ℝ``，并尝试理解点``(x₀， y₀)``的邻域与``𝓝 x₀``和``𝓝 y₀``之间的关系。
 存在一个乘积运算``Filter.prod ： Filter X → Filter Y → Filter (X × Y)``，记作``×ˢ``，它回答了这个问题：
 EXAMPLES: -/
@@ -327,19 +200,6 @@ example : 𝓝 (x₀, y₀) = 𝓝 x₀ ×ˢ 𝓝 y₀ :=
 -- QUOTE.
 
 /- TEXT:
--- The product operation is defined in terms of the pullback operation and the ``inf`` operation:
-
---   ``F ×ˢ G = (comap Prod.fst F) ⊓ (comap Prod.snd G)``.
-
--- Here the ``inf`` operation refers to the lattice structure on ``Filter X`` for any type ``X``, whereby
--- ``F ⊓ G`` is the greatest filter that is smaller than both ``F`` and ``G``.
--- Thus the ``inf`` operation generalizes the notion of the intersection of sets.
-
--- A lot of proofs in Mathlib use all of the aforementioned structure (``map``, ``comap``, ``inf``, ``sup``, and ``prod``)
--- to give algebraic proofs about convergence without ever referring to members of filters.
--- You can practice doing this in a proof of the following lemma, unfolding the definition of ``Tendsto``
--- and ``Filter.prod`` if needed.
-
 该乘积运算通过拉回运算和``inf``运算来定义：
 
 ``F ×ˢ G = (comap Prod.fst F) ⊓ (comap Prod.snd G)``
@@ -384,73 +244,16 @@ example (f : ℕ → ℝ × ℝ) (x₀ y₀ : ℝ) :
   rw [le_inf_iff, ← map_le_iff_le_comap, map_map, ← map_le_iff_le_comap, map_map]
 
 /- TEXT:
--- The ordered type ``Filter X`` is actually a *complete* lattice,
--- which is to say, there is a bottom element, there is a top element, and
--- every set of filters on ``X`` has an ``Inf`` and a ``Sup``.
-
 有序类型``Filter X``实际上是一个**完备**格，也就是说，存在一个最小元素，存在一个最大元素，并且 X 上的每个滤子集都有一个``Inf``和一个``Sup``。
-
--- Note that given the second property in the definition of a filter
--- (if ``U`` belongs to ``F`` then anything larger than ``U`` also belongs to ``F``),
--- the first property
--- (the set of all inhabitants of ``X`` belongs to ``F``) is
--- equivalent to the property that ``F`` is not the empty collection of sets.
--- This shouldn't be confused with the more subtle question as to whether
--- the empty set is an *element* of ``F``. The
--- definition of a filter does not prohibit ``∅ ∈ F``,
--- but if the empty set is in ``F`` then
--- every set is in ``F``, which is to say, ``∀ U : Set X, U ∈ F``.
--- In this case, ``F`` is a rather trivial filter, which is precisely the
--- bottom element of the complete lattice ``Filter X``.
--- This contrasts with the definition of filters in
--- Bourbaki, which doesn't allow filters containing the empty set.
 
 请注意，根据滤子定义中的第二个性质（如果``U``属于``F``，那么任何包含``U``的集合也属于``F``），第一个性质（``X``的所有元素组成的集合属于``F``）等价于``F``不是空集合这一性质。这不应与更微妙的问题相混淆，即空集是否为``F``的一个**元素**。滤子的定义并不禁止``∅ ∈ F``，但如果空集在``F``中，那么每个集合都在``F``中，也就是说，``∀ U : Set X, U ∈ F``。在这种情况下，``F``是一个相当平凡的滤子，恰好是完备格``Filter X``的最小元素。这与布尔巴基对滤子的定义形成对比，布尔巴基的定义不允许滤子包含空集。
 
--- Because we include the trivial filter in our definition, we sometimes need to explicitly assume
--- nontriviality in some lemmas.
--- In return, however, the theory has nicer global properties.
--- We have already seen that including the trivial filter gives us a
--- bottom element. It also allows us to define ``principal : Set X → Filter X``,
--- which maps  ``∅`` to ``⊥``, without adding a precondition to rule out the empty set.
--- And it allows us to define the pullback operation without a precondition as well.
--- Indeed, it can happen that ``comap f F = ⊥`` although ``F ≠ ⊥``. For instance,
--- given ``x₀ : ℝ`` and ``s : Set ℝ``, the pullback of ``𝓝 x₀`` under the coercion
--- from the subtype corresponding to ``s`` is nontrivial if and only if ``x₀`` belongs to the
--- closure of ``s``.
-
 由于我们在定义中包含了平凡滤子，所以在某些引理中有时需要明确假设非平凡性。不过作为回报，该理论具有更优的整体性质。我们已经看到，包含平凡滤子为我们提供了一个最小元素。它还允许我们定义``principal ： Set X → Filter X``，将``∅``映射到``⊥``，而无需添加预条件来排除空集。而且它还允许我们定义拉回操作时无需预条件。实际上，有可能``comap f F = ⊥``尽管``F ≠ ⊥``。例如，给定``x₀ ： ℝ``和``s : Set ℝ``，``𝓝 x₀``在从与``s``对应的子类型强制转换下的拉回非平凡当且仅当``x₀``属于``s``的闭包。
-
--- In order to manage lemmas that do need to assume some filter is nontrivial, Mathlib has
--- a type class ``Filter.NeBot``, and the library has lemmas that assume
--- ``(F : Filter X) [F.NeBot]``. The instance database knows, for example, that ``(atTop : Filter ℕ).NeBot``,
--- and it knows that pushing forward a nontrivial filter gives a nontrivial filter.
--- As a result, a lemma assuming ``[F.NeBot]`` will automatically apply to ``map u atTop`` for any sequence ``u``.
 
 为了管理确实需要假设某些滤子非平凡的引理，Mathlib 设有类型类``Filter.NeBot``，并且库中存在假设``（F : Filter X）[F.NeBot]``的引理。实例数据库知道，例如，``(atTop : Filter ℕ).NeBot``，并且知道将非平凡滤子向前推进会得到一个非平凡滤子。因此，假设``[F.NeBot]``的引理将自动应用于任何序列``u``的``map u atTop``。
 
--- Our tour of the algebraic properties of filters and their relation to limits is essentially done,
--- but we have not yet justified our claim to have recaptured the usual limit notions.
--- Superficially, it may seem that ``Tendsto u atTop (𝓝 x₀)``
--- is stronger than the notion of convergence defined in :numref:`sequences_and_convergence` because we ask that *every* neighborhood of ``x₀``
--- has a preimage belonging to ``atTop``, whereas the usual definition only requires
--- this for the standard neighborhoods ``Ioo (x₀ - ε) (x₀ + ε)``.
--- The key is that, by definition, every neighborhood contains such a standard one.
--- This observation leads to the notion of a *filter basis*.
-
-
 我们对滤子的代数性质及其与极限的关系的探讨基本上已经完成，但我们尚未证明我们所提出的重新捕捉通常极限概念的主张是合理的。
 表面上看，``Tendsto u atTop (𝓝 x₀)``似乎比在 :numref:``sequences_and_convergence`` 中定义的收敛概念更强，因为我们要求``x₀``的**每个**邻域都有一个属于``atTop``的原像，而通常的定义仅要求对于标准邻域``Ioo (x₀ - ε) (x₀ + ε)``满足这一条件。关键在于，根据定义，每个邻域都包含这样的标准邻域。这一观察引出了**滤子基（filter basis）**的概念。
-
--- Given ``F : Filter X``,
--- a family of sets ``s : ι → Set X`` is a basis for ``F`` if for every set ``U``,
--- we have ``U ∈ F`` if and only if it contains some ``s i``. In other words, formally speaking,
--- ``s`` is a basis if it satisfies
--- ``∀ U : Set X, U ∈ F ↔ ∃ i, s i ⊆ U``. It is even more flexible to consider
--- a predicate on ``ι`` that selects only some of the values ``i`` in the indexing type.
--- In the case of ``𝓝 x₀``, we want ``ι`` to be ``ℝ``, we write ``ε`` for ``i``, and the predicate should select the positive values of ``ε``.
--- So the fact that the sets ``Ioo  (x₀ - ε) (x₀ + ε)`` form a basis for the
--- neighborhood topology on ``ℝ`` is stated as follows:
 
 给定``F : Filter X``，如果对于每个集合``U``，我们有``U ∈ F``当且仅当它包含某个``s i``，那么集合族``s ： ι → Set X``就是``F``的基。
 换句话说，严格说来，``s``是基当且仅当它满足``∀ U : Set X, U ∈ F ↔ ∃ i, s i ⊆ U``。考虑在索引类型中仅选择某些值``i``的``ι``上的谓词会更加灵活。
@@ -462,13 +265,6 @@ example (x₀ : ℝ) : HasBasis (𝓝 x₀) (fun ε : ℝ ↦ 0 < ε) fun ε ↦
 -- QUOTE.
 
 /- TEXT:
--- There is also a nice basis for the filter ``atTop``. The lemma
--- ``Filter.HasBasis.tendsto_iff`` allows
--- us to reformulate a statement of the form ``Tendsto f F G``
--- given bases for ``F`` and ``G``.
--- Putting these pieces together gives us essentially the notion of convergence
--- that we used in :numref:`sequences_and_convergence`.
-
 还有一个很好的``atTop``滤子的基础。引理``Filter.HasBasis.tendsto_iff``允许我们在给定``F``和``G``的基础的情况下，重新表述形式为``Tendsto f F G``的陈述。将这些部分组合在一起，就基本上得到了我们在 :numref:``sequences_and_convergence`` 中使用的收敛概念。
 EXAMPLES: -/
 -- QUOTE:
@@ -480,26 +276,8 @@ example (u : ℕ → ℝ) (x₀ : ℝ) :
 -- QUOTE.
 
 /- TEXT:
--- We now show how filters facilitate working with properties that hold for sufficiently large numbers
--- or for points that are sufficiently close to a given point. In :numref:`sequences_and_convergence`, we were often faced with the situation where
--- we knew that some property ``P n`` holds for sufficiently large ``n`` and that some
--- other property ``Q n`` holds for sufficiently large ``n``.
--- Using ``cases`` twice gave us ``N_P`` and ``N_Q`` satisfying
--- ``∀ n ≥ N_P, P n`` and ``∀ n ≥ N_Q, Q n``. Using ``set N := max N_P N_Q``, we could
--- eventually prove ``∀ n ≥ N, P n ∧ Q n``.
--- Doing this repeatedly becomes tiresome.
 
 现在我们展示一下滤子如何有助于处理对于足够大的数字或对于给定点足够近的点成立的性质。在 :numref:`sequences_and_convergence` 中，我们经常遇到这样的情况：我们知道某个性质 ``P n`` 对于足够大的 ``n`` 成立，而另一个性质 ``Q n`` 对于足够大的 ``n`` 也成立。使用两次 ``cases`` 得到了满足 ``∀ n ≥ N_P， P n`` 和 ``∀ n ≥ N_Q， Q n`` 的 ``N_P`` 和 ``N_Q``。通过 ``set N := max N_P N_Q``，我们最终能够证明 ``∀ n ≥ N， P n ∧ Q n``。反复这样做会让人感到厌烦。
-
--- We can do better by noting that the statement "``P n`` and ``Q n`` hold for large enough ``n``" means
--- that we have ``{n | P n} ∈ atTop`` and ``{n | Q n} ∈ atTop``.
--- The fact that ``atTop`` is a filter implies that the intersection of two elements of ``atTop``
--- is again in ``atTop``, so we have ``{n | P n ∧ Q n} ∈ atTop``.
--- Writing ``{n | P n} ∈ atTop`` is unpleasant,
--- but we can use the more suggestive notation ``∀ᶠ n in atTop, P n``.
--- Here the superscripted ``f`` stands for "Filter."
--- You can think of the notation as saying that for all ``n`` in the "set of very large numbers," ``P n`` holds. The ``∀ᶠ``
--- notation stands for ``Filter.Eventually``, and the lemma ``Filter.Eventually.and`` uses the intersection property of filters to do what we just described:
 
 我们可以通过注意到“对于足够大的 n，``P n`` 和 ``Q n`` 成立”这一表述意味着我们有 ``{n | P n} ∈ atTop`` 和 ``{n | Q n} ∈ atTop`` 来做得更好。由于 ``atTop`` 是一个滤子，所以 ``atTop`` 中两个元素的交集仍在 ``atTop`` 中，因此我们有 ``{n | P n ∧ Q n} ∈ atTop``。书写 ``{n | P n} ∈ atTop`` 不太美观，但我们可以用更具提示性的记号 ``∀ᶠ n in atTop， P n``。这里的上标 ``f`` 表示“滤子”。你可以将这个记号理解为对于“非常大的数集”中的所有 ``n``，``P n`` 成立。``∀ᶠ`` 记号代表 ``Filter.Eventually``，而引理 ``Filter.Eventually.and`` 利用滤子的交集性质来实现我们刚才所描述的操作：
 EXAMPLES: -/
@@ -510,14 +288,6 @@ example (P Q : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in atT
 -- QUOTE.
 
 /- TEXT:
--- This notation is so convenient and intuitive that we also have specializations
--- when ``P`` is an equality or inequality statement. For example, let ``u`` and ``v`` be
--- two sequences of real numbers, and let us show that if
--- ``u n`` and ``v n`` coincide for sufficiently large ``n`` then
--- ``u`` tends to ``x₀`` if and only if ``v`` tends to ``x₀``.
--- First we'll use the generic ``Eventually`` and then the one
--- specialized for the equality predicate, ``EventuallyEq``. The two statements are
--- definitionally equivalent so the same proof work in both cases.
 
 这种表示法如此方便且直观，以至于当``P``是一个等式或不等式陈述时，我们也有专门的表示形式。例如，设``u``和``v``是两个实数序列，让我们证明如果对于足够大的``n``，``u n``和``v n``相等，那么``u``趋向于``x₀``当且仅当``v``趋向于``x₀``。首先我们将使用通用的``Eventually``，然后使用专门针对等式谓词的``EventuallyEq``。这两个陈述在定义上是等价的，因此在两种情况下相同的证明都适用。
 EXAMPLES: -/
@@ -532,12 +302,6 @@ example (u v : ℕ → ℝ) (h : u =ᶠ[atTop] v) (x₀ : ℝ) :
 -- QUOTE.
 
 /- TEXT:
--- It is instructive to review the definition of filters in terms of ``Eventually``.
--- Given ``F : Filter X``, for any predicates ``P`` and ``Q`` on ``X``,
-
--- * the condition ``univ ∈ F`` ensures ``(∀ x, P x) → ∀ᶠ x in F, P x``,
--- * the condition ``U ∈ F → U ⊆ V → V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ x, P x → Q x) → ∀ᶠ x in F, Q x``, and
--- * the condition ``U ∈ F → V ∈ F → U ∩ V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ᶠ x in F, Q x) → ∀ᶠ x in F, P x ∧ Q x``.
 
 从``Eventually``这一概念的角度来审视滤子的定义是很有启发性的。
 给定滤子 ``F : Filter X`` ，对于 ``X`` 上的任意谓词 ``P`` 和 ``Q`` ，
@@ -553,10 +317,6 @@ EXAMPLES: -/
 -- QUOTE.
 
 /- TEXT:
--- The second item, corresponding to ``Eventually.mono``, supports nice ways
--- of using filters, especially when combined
--- with ``Eventually.and``. The ``filter_upwards`` tactic allows us to combine them.
--- Compare:
 
 第二个项目，对应于``Eventually.mono``，支持使用滤子的优雅方式，尤其是与``Eventually.and``结合使用时。``filter_upwards`` 策略使我们能够将它们组合起来。比较：
 EXAMPLES: -/
@@ -574,46 +334,17 @@ example (P Q R : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in a
 -- QUOTE.
 
 /- TEXT:
--- Readers who know about measure theory will note that the filter ``μ.ae`` of sets whose complement has measure zero
--- (aka "the set consisting of almost every point") is not very useful as the source or target of ``Tendsto``, but it can be conveniently
--- used with ``Eventually`` to say that a property holds for almost every point.
 
 熟悉测度论的读者会注意到，补集测度为零的集合构成的滤子``μ.ae``（即“几乎每个点构成的集合”）作为``Tendsto``的源或目标并不是很有用，但它可以方便地与``Eventually``一起使用，以表明某个性质对几乎每个点都成立。
 
--- There is a dual version of ``∀ᶠ x in F, P x``, which is occasionally useful:
--- ``∃ᶠ x in F, P x`` means
--- ``{x | ¬P x} ∉ F``. For example, ``∃ᶠ n in atTop, P n`` means there are arbitrarily large ``n`` such that ``P n`` holds.
--- The ``∃ᶠ`` notation stands for ``Filter.Frequently``.
-
--- There is a dual version of ``∀ᶠ x in F, P x``, which is occasionally useful:
--- ``∃ᶠ x in F, P x`` means
--- ``{x | ¬P x} ∉ F``. For example, ``∃ᶠ n in atTop, P n`` means there are arbitrarily large ``n`` such that ``P n`` holds.
--- The ``∃ᶠ`` notation stands for ``Filter.Frequently``.
-
-存在``∀ᶠ x in F, P x``的双重版本，有时会很有用：
+存在``∀ᶠ x in F, P x``的对偶版本，有时会很有用：
 用``∃ᶠ x in F, P x``表示
 ``{x | ¬P x} ∉ F``。例如，``∃ᶠ n in atTop, P n``意味着存在任意大的 ``n`` 使得 ``P n`` 成立。
 ``∃ᶠ``符号代表``Filter.Frequently``。
 
--- For a more sophisticated example, consider the following statement about a sequence
--- ``u``, a set ``M``, and a value ``x``:
-
 对于一个更复杂的示例，请考虑以下关于序列 ``u``、集合 ``M`` 和值 ``x`` 的陈述：
 
-  -- If ``u`` converges to ``x`` and ``u n`` belongs to ``M`` for
-  -- sufficiently large ``n`` then ``x`` is in the closure of ``M``.
-
 如果序列 ``u`` 收敛于 ``x`` ，且对于足够大的 ``n`` ，``u n`` 属于集合 ``M`` ，那么 ``x`` 就在集合 ``M`` 的闭包内。
-
--- This can be formalized as follows:
-
---   ``Tendsto u atTop (𝓝 x) → (∀ᶠ n in atTop, u n ∈ M) → x ∈ closure M``.
-
--- This is a special case of the theorem ``mem_closure_of_tendsto`` from the
--- topology library.
--- See if you can prove it using the quoted lemmas,
--- using the fact that ``ClusterPt x F`` means ``(𝓝 x ⊓ F).NeBot`` and that,
--- by definition, the assumption ``∀ᶠ n in atTop, u n ∈ M`` means  ``M ∈ map u atTop``.
 
 这可以形式化表述如下：
 

--- a/MIL/C10_Topology/S01_Filters.lean
+++ b/MIL/C10_Topology/S01_Filters.lean
@@ -8,54 +8,87 @@ open Set Filter Topology
 
 .. _filters:
 
-Filters
+-- Filters
+
+滤子
 -------
 
-A *filter* on a type ``X`` is a collection of sets of ``X`` that satisfies three
-conditions that we will spell out below. The notion
-supports two related ideas:
+-- A *filter* on a type ``X`` is a collection of sets of ``X`` that satisfies three
+-- conditions that we will spell out below. The notion
+-- supports two related ideas:
 
-* *limits*, including all the kinds of limits discussed above: finite and infinite limits of sequences, finite and infinite limits of functions at a point or at infinity, and so on.
+类型 ``X`` 上的 **滤子** 是 ``X`` 的集合的集合，满足以下三个条件（我们将在下面详细说明）。该概念支持两个相关的想法：
 
-* *things happening eventually*, including things happening for large enough ``n : ℕ``, or sufficiently near a point ``x``, or for sufficiently close pairs of points, or almost everywhere in the sense of measure theory. Dually, filters can also express the idea of *things happening often*: for arbitrarily large ``n``, at a point in any neighborhood of a given point, etc.
+-- * *limits*, including all the kinds of limits discussed above: finite and infinite limits of sequences, finite and infinite limits of functions at a point or at infinity, and so on.
 
-The filters that correspond to these descriptions will be defined later in this section, but we can already name them:
+* **极限**，包括上述讨论过的各种极限：数列的有限极限和无穷极限、函数在某点或无穷远处的有限极限和无穷极限等等。
 
-* ``(atTop : Filter ℕ)``, made of sets of ``ℕ`` containing ``{n | n ≥ N}`` for some ``N``
-* ``𝓝 x``, made of neighborhoods of ``x`` in a topological space
-* ``𝓤 X``, made of entourages of a uniform space (uniform spaces generalize metric spaces and topological groups)
-* ``μ.ae`` , made of sets whose complement has zero measure with respect to a measure ``μ``.
+-- * *things happening eventually*, including things happening for large enough ``n : ℕ``, or sufficiently near a point ``x``, or for sufficiently close pairs of points, or almost everywhere in the sense of measure theory. Dually, filters can also express the idea of *things happening often*: for arbitrarily large ``n``, at a point in any neighborhood of a given point, etc.
 
-The general definition is as follows: a filter ``F : Filter X`` is a
-collection of sets ``F.sets : Set (Set X)`` satisfying the following:
+* **最终发生的事情**，包括对于足够大的自然数 ``n ： ℕ`` 发生的事情，或者在某一点 ``x`` 足够近的地方发生的事情，或者对于足够接近的点对发生的事情，或者在测度论意义上几乎处处发生的事情。对偶地，滤子也可以表达**经常发生的事情**的概念：对于任意大的 ``n`` ，在给定点的任意邻域内存在某点发生，等等。
+
+-- The filters that correspond to these descriptions will be defined later in this section, but we can already name them:
+
+与这些描述相对应的滤子将在本节稍后定义，但我们现在就可以给它们命名：
+
+-- * ``(atTop : Filter ℕ)``, made of sets of ``ℕ`` containing ``{n | n ≥ N}`` for some ``N``
+-- * ``𝓝 x``, made of neighborhoods of ``x`` in a topological space
+-- * ``𝓤 X``, made of entourages of a uniform space (uniform spaces generalize metric spaces and topological groups)
+-- * ``μ.ae`` , made of sets whose complement has zero measure with respect to a measure ``μ``.
+
+* ``(atTop : Filter ℕ)``，由包含 ``{n | n ≥ N}`` 的 ``ℕ`` 的集合构成，其中 ``N`` 为某个自然数
+* ``𝓝 x``，由拓扑空间中 ``x`` 的邻域构成
+* ``𝓤 X``，由一致空间的邻域基构成（一致空间推广了度量空间和拓扑群）
+* ``μ.ae``，由相对于测度 ``μ`` 其补集测度为零的集合构成
+
+-- The general definition is as follows: a filter ``F : Filter X`` is a
+-- collection of sets ``F.sets : Set (Set X)`` satisfying the following:
+
+一般的定义如下：一个滤子 ``F : Filter X`` 是集合 ``F.sets : Set (Set X)`` 的一个集合，满足以下条件：
+
+-- * ``F.univ_sets : univ ∈ F.sets``
+-- * ``F.sets_of_superset : ∀ {U V}, U ∈ F.sets → U ⊆ V → V ∈ F.sets``
+-- * ``F.inter_sets : ∀ {U V}, U ∈ F.sets → V ∈ F.sets → U ∩ V ∈ F.sets``.
 
 * ``F.univ_sets : univ ∈ F.sets``
 * ``F.sets_of_superset : ∀ {U V}, U ∈ F.sets → U ⊆ V → V ∈ F.sets``
 * ``F.inter_sets : ∀ {U V}, U ∈ F.sets → V ∈ F.sets → U ∩ V ∈ F.sets``.
 
-The first condition says that the set of all elements of ``X`` belongs to ``F.sets``.
-The second condition says that if ``U`` belongs to ``F.sets`` then anything
-containing ``U`` also belongs to ``F.sets``.
-The third condition says that ``F.sets`` is closed under finite intersections.
-In Mathlib, a filter ``F`` is defined to be a structure bundling ``F.sets`` and its
-three properties, but the properties carry no additional data,
-and it is convenient to blur the distinction between ``F`` and ``F.sets``. We
-therefore define ``U ∈ F`` to mean ``U ∈ F.sets``.
-This explains why the word ``sets`` appears in the names of some lemmas that
-that mention ``U ∈ F``.
+-- The first condition says that the set of all elements of ``X`` belongs to ``F.sets``.
+-- The second condition says that if ``U`` belongs to ``F.sets`` then anything
+-- containing ``U`` also belongs to ``F.sets``.
+-- The third condition says that ``F.sets`` is closed under finite intersections.
+-- In Mathlib, a filter ``F`` is defined to be a structure bundling ``F.sets`` and its
+-- three properties, but the properties carry no additional data,
+-- and it is convenient to blur the distinction between ``F`` and ``F.sets``. We
+-- therefore define ``U ∈ F`` to mean ``U ∈ F.sets``.
+-- This explains why the word ``sets`` appears in the names of some lemmas that
+-- that mention ``U ∈ F``.
 
-It may help to think of a filter as defining a notion of a "sufficiently large" set. The first
-condition then says that ``univ`` is sufficiently large, the second one says that a set containing a sufficiently
-large set is sufficiently large and the third one says that the intersection of two sufficiently large sets
-is sufficiently large.
+第一个条件表明，集合 ``X`` 的所有元素都属于 ``F.sets``。
+第二个条件表明，如果 ``U`` 属于 ``F.sets``，那么包含 ``U`` 的任何集合也属于 ``F.sets``。
+第三个条件表明，``F.sets`` 对有限交集是封闭的。
+在 Mathlib 中，滤子 ``F`` 被定义为捆绑 ``F.sets`` 及其三个属性的结构，但这些属性不携带额外的数据，并且将 ``F`` 和 ``F.sets`` 之间的区别模糊化是方便的。我们
+因此，将``U ∈ F``定义为``U ∈ F.sets``。
+这就解释了为什么在一些提及``U ∈ F``的引理名称中会出现``sets``这个词。
 
-It may be even  more useful to think of a filter on a type ``X``
-as a generalized element of ``Set X``. For instance, ``atTop`` is the
-"set of very large numbers" and ``𝓝 x₀`` is the "set of points very close to ``x₀``."
-One manifestation of this view is that we can associate to any ``s : Set X`` the so-called *principal filter*
-consisting of all sets that contain ``s``.
-This definition is already in Mathlib and has a notation ``𝓟`` (localized in the ``Filter`` namespace).
-For the purpose of demonstration, we ask you to take this opportunity to work out the definition here.
+-- It may help to think of a filter as defining a notion of a "sufficiently large" set. The first
+-- condition then says that ``univ`` is sufficiently large, the second one says that a set containing a sufficiently
+-- large set is sufficiently large and the third one says that the intersection of two sufficiently large sets
+-- is sufficiently large.
+
+可以将滤子视为定义“足够大”集合的概念。第一个条件表明``univ``是足够大的集合，第二个条件表明包含足够大集合的集合也是足够大的集合，第三个条件表明两个足够大集合的交集也是足够大的集合。
+
+-- It may be even  more useful to think of a filter on a type ``X``
+-- as a generalized element of ``Set X``. For instance, ``atTop`` is the
+-- "set of very large numbers" and ``𝓝 x₀`` is the "set of points very close to ``x₀``."
+-- One manifestation of this view is that we can associate to any ``s : Set X`` the so-called *principal filter*
+-- consisting of all sets that contain ``s``.
+-- This definition is already in Mathlib and has a notation ``𝓟`` (localized in the ``Filter`` namespace).
+-- For the purpose of demonstration, we ask you to take this opportunity to work out the definition here.
+
+将类型``X``上的一个滤子视为``Set X``的广义元素，可能更有用。例如，``atTop`` 是“极大数的集合”，而 ``𝓝 x₀`` 是“非常接近 ``x₀`` 的点的集合”。这种观点的一种体现是，我们可以将任何 ``s ： Set X`` 与所谓的“主滤子”相关联，该主滤子由包含 ``s`` 的所有集合组成。
+此定义已在 Mathlib 中，并有一个记号 ``𝓟``（在 ``Filter`` 命名空间中本地化）。为了演示的目的，我们请您借此机会在此处推导出该定义。
 EXAMPLES: -/
 -- QUOTE:
 def principal {α : Type*} (s : Set α) : Filter α
@@ -68,6 +101,7 @@ def principal {α : Type*} (s : Set α) : Filter α
 
 -- SOLUTIONS:
 -- In the next example we could use `tauto` in each proof instead of knowing the lemmas
+-- 在下一个示例中，我们可以在每个证明中使用 `tauto` 而不是记住这些引理
 example {α : Type*} (s : Set α) : Filter α :=
   { sets := { t | s ⊆ t }
     univ_sets := subset_univ s
@@ -75,8 +109,10 @@ example {α : Type*} (s : Set α) : Filter α :=
     inter_sets := fun hU hV ↦ subset_inter hU hV }
 
 /- TEXT:
-For our second example, we ask you to define the filter ``atTop : Filter ℕ``.
-(We could use any type with a preorder instead of ``ℕ``.)
+-- For our second example, we ask you to define the filter ``atTop : Filter ℕ``.
+-- (We could use any type with a preorder instead of ``ℕ``.)
+
+对于我们的第二个示例，我们请您定义滤子 ``atTop : Filter ℕ`` 。（我们也可以使用任何具有预序关系的类型来代替 ``ℕ``。）
 EXAMPLES: -/
 -- QUOTE:
 example : Filter ℕ :=
@@ -104,15 +140,19 @@ example : Filter ℕ :=
       constructor <;> tauto }
 
 /- TEXT:
-We can also directly define the filter ``𝓝 x`` of neighborhoods of any ``x : ℝ``.
-In the real numbers, a neighborhood of ``x`` is a set containing an open interval
-:math:`(x_0 - \varepsilon, x_0 + \varepsilon)`,
-defined in Mathlib as ``Ioo (x₀ - ε) (x₀ + ε)``.
-(This is notion of a neighborhood is only a special case of a more general construction in Mathlib.)
+-- We can also directly define the filter ``𝓝 x`` of neighborhoods of any ``x : ℝ``.
+-- In the real numbers, a neighborhood of ``x`` is a set containing an open interval
+-- :math:`(x_0 - \varepsilon, x_0 + \varepsilon)`,
+-- defined in Mathlib as ``Ioo (x₀ - ε) (x₀ + ε)``.
+-- (This is notion of a neighborhood is only a special case of a more general construction in Mathlib.)
 
-With these examples, we can already define what is means for a function ``f : X → Y``
-to converge to some ``G : Filter Y`` along some ``F : Filter X``,
-as follows:
+我们还可以直接定义任意实数 ``x ： ℝ`` 的邻域滤子 ``𝓝 x`` 。在实数中，``x`` 的邻域是一个包含开区间 :math:`(x_0 - \varepsilon, x_0 + \varepsilon)` 的集合，在 Mathlib 中定义为 ``Ioo (x₀ - ε) (x₀ + ε)`` 。（Mathlib 中的这种邻域概念只是更一般构造的一个特例。）
+
+-- With these examples, we can already define what is means for a function ``f : X → Y``
+-- to converge to some ``G : Filter Y`` along some ``F : Filter X``,
+-- as follows:
+
+有了这些例子，我们就可以定义函数 ``f : X → Y`` 沿着某个 ``F : Filter X`` 收敛到某个 ``G : Filter Y`` 的含义，如下所述：
 BOTH: -/
 -- QUOTE:
 def Tendsto₁ {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :=
@@ -120,24 +160,28 @@ def Tendsto₁ {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :=
 -- QUOTE.
 
 /- TEXT:
-When ``X`` is ``ℕ`` and ``Y`` is ``ℝ``, ``Tendsto₁ u atTop (𝓝 x)`` is equivalent to saying that the sequence ``u : ℕ → ℝ``
-converges to the real number ``x``. When both ``X`` and ``Y`` are ``ℝ``, ``Tendsto f (𝓝 x₀) (𝓝 y₀)``
-is equivalent to the familiar notion :math:`\lim_{x \to x₀} f(x) = y₀`.
-All of the other kinds of limits mentioned in the introduction are
-also equivalent to instances of ``Tendsto₁`` for suitable choices of filters on the source and target.
+-- When ``X`` is ``ℕ`` and ``Y`` is ``ℝ``, ``Tendsto₁ u atTop (𝓝 x)`` is equivalent to saying that the sequence ``u : ℕ → ℝ``
+-- converges to the real number ``x``. When both ``X`` and ``Y`` are ``ℝ``, ``Tendsto f (𝓝 x₀) (𝓝 y₀)``
+-- is equivalent to the familiar notion :math:`\lim_{x \to x₀} f(x) = y₀`.
+-- All of the other kinds of limits mentioned in the introduction are
+-- also equivalent to instances of ``Tendsto₁`` for suitable choices of filters on the source and target.
 
-The notion ``Tendsto₁`` above is definitionally equivalent to the notion ``Tendsto`` that is defined in Mathlib,
-but the latter is defined more abstractly.
-The problem with the definition of ``Tendsto₁`` is that it exposes a quantifier and elements of ``G``,
-and it hides the intuition that we get by viewing filters as generalized sets. We can
-hide the quantifier ``∀ V`` and make the intuition more salient by using more algebraic and set-theoretic machinery.
-The first ingredient is the *pushforward* operation :math:`f_*` associated to any map ``f : X → Y``,
-denoted ``Filter.map f`` in Mathlib. Given a filter ``F`` on ``X``, ``Filter.map f F : Filter Y`` is defined so that
-``V ∈ Filter.map f F ↔ f ⁻¹' V ∈ F`` holds definitionally.
-In this examples file we've opened the ``Filter`` namespace so that
-``Filter.map`` can be written as ``map``. This means that we can rewrite the definition of ``Tendsto`` using
-the order relation on ``Filter Y``, which is reversed inclusion of the set of members.
-In other words, given ``G H : Filter Y``, we have ``G ≤ H ↔ ∀ V : Set Y, V ∈ H → V ∈ G``.
+当 ``X`` 为 ``ℕ`` 且 ``Y`` 为 ``ℝ`` 时，``Tendsto₁ u atTop (𝓝 x)`` 等价于说序列 ``u ： ℕ → ℝ`` 收敛于实数 ``x`` 。当 ``X`` 和 ``Y`` 均为 ``ℝ`` 时，``Tendsto f (𝓝 x₀) (𝓝 y₀)`` 等价于熟悉的概念 :math:`\lim_{x \to x₀} f(x) = y₀` 。介绍中提到的所有其他类型的极限也等价于对源和目标上适当选择的滤子的 ``Tendsto₁`` 的实例。
+
+-- The notion ``Tendsto₁`` above is definitionally equivalent to the notion ``Tendsto`` that is defined in Mathlib,
+-- but the latter is defined more abstractly.
+-- The problem with the definition of ``Tendsto₁`` is that it exposes a quantifier and elements of ``G``,
+-- and it hides the intuition that we get by viewing filters as generalized sets. We can
+-- hide the quantifier ``∀ V`` and make the intuition more salient by using more algebraic and set-theoretic machinery.
+-- The first ingredient is the *pushforward* operation :math:`f_*` associated to any map ``f : X → Y``,
+-- denoted ``Filter.map f`` in Mathlib. Given a filter ``F`` on ``X``, ``Filter.map f F : Filter Y`` is defined so that
+-- ``V ∈ Filter.map f F ↔ f ⁻¹' V ∈ F`` holds definitionally.
+-- In this examples file we've opened the ``Filter`` namespace so that
+-- ``Filter.map`` can be written as ``map``. This means that we can rewrite the definition of ``Tendsto`` using
+-- the order relation on ``Filter Y``, which is reversed inclusion of the set of members.
+-- In other words, given ``G H : Filter Y``, we have ``G ≤ H ↔ ∀ V : Set Y, V ∈ H → V ∈ G``.
+
+上述的``Tendsto₁``概念在定义上等同于在 Mathlib 中定义的``Tendsto``概念，但后者定义得更为抽象。``Tendsto₁``的定义存在的问题是它暴露了量词和``G``的元素，并且掩盖了通过将滤子视为广义集合所获得的直观理解。我们可以通过使用更多的代数和集合论工具来隐藏量词``∀ V``，并使这种直观理解更加突出。第一个要素是与任何映射``f : X → Y``相关的**前推**操作 ：math:`f_*`，在 Mathlib 中记为``Filter.map f``。给定``X``上的滤子``F``，``Filter.map f F ： Filter Y``被定义为使得``V ∈ Filter.map f F ↔ f ⁻¹' V ∈ F``成立。在这个示例文件中，我们已经打开了``Filter``命名空间，因此``Filter.map``可以写成``map``。这意味着我们可以使用``Filter Y``上的序关系来重写``Tendsto``的定义，该序关系是成员集合的反向包含关系。换句话说，给定``G H ： Filter Y``，我们有``G ≤ H ↔ ∀ V ： Set Y， V ∈ H → V ∈ G``。
 EXAMPLES: -/
 -- QUOTE:
 def Tendsto₂ {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :=
@@ -149,21 +193,29 @@ example {X Y : Type*} (f : X → Y) (F : Filter X) (G : Filter Y) :
 -- QUOTE.
 
 /- TEXT:
-It may seem that the order relation on filters is backward. But recall that we can view filters on ``X`` as
-generalized elements of ``Set X``, via the inclusion of ``𝓟 : Set X → Filter X`` which maps any set ``s`` to the corresponding principal filter.
-This inclusion is order preserving, so the order relation on ``Filter`` can indeed be seen as the natural inclusion relation
-between generalized sets. In this analogy, pushforward is analogous to the direct image.
-And, indeed, ``map f (𝓟 s) = 𝓟 (f '' s)``.
+-- It may seem that the order relation on filters is backward. But recall that we can view filters on ``X`` as
+-- generalized elements of ``Set X``, via the inclusion of ``𝓟 : Set X → Filter X`` which maps any set ``s`` to the corresponding principal filter.
+-- This inclusion is order preserving, so the order relation on ``Filter`` can indeed be seen as the natural inclusion relation
+-- between generalized sets. In this analogy, pushforward is analogous to the direct image.
+-- And, indeed, ``map f (𝓟 s) = 𝓟 (f '' s)``.
 
-We can now understand intuitively why a sequence ``u : ℕ → ℝ`` converges to
-a point ``x₀`` if and only if we have ``map u atTop ≤ 𝓝 x₀``.
-The inequality means the "direct image under ``u``" of
-"the set of very big natural numbers" is "included" in "the set of points very close to ``x₀``."
+可能看起来滤子上的序关系是反向的。但请回想一下，我们可以通过将任何集合 ``s`` 映射到相应的主滤子的 ``𝓟 ： Set X → Filter X`` 的包含关系，将 ``X`` 上的滤子视为 ``Set X`` 的广义元素。这种包含关系是保序的，因此 ``Filter`` 上的序关系确实可以被视为广义集合之间的自然包含关系。在这个类比中，前推类似于直接像（direct image）。而且，确实有 ``map f (𝓟 s) = 𝓟 (f '' s)``。
 
-As promised, the definition of ``Tendsto₂`` does not exhibit any quantifiers or sets.
-It also leverages the algebraic properties of the pushforward operation.
-First, each ``Filter.map f`` is monotone. And, second, ``Filter.map`` is compatible with
-composition.
+-- We can now understand intuitively why a sequence ``u : ℕ → ℝ`` converges to
+-- a point ``x₀`` if and only if we have ``map u atTop ≤ 𝓝 x₀``.
+-- The inequality means the "direct image under ``u``" of
+-- "the set of very big natural numbers" is "included" in "the set of points very close to ``x₀``."
+
+现在我们可以直观地理解为什么一个序列 ``u ： ℕ → ℝ`` 收敛于点 ``x₀`` 当且仅当 ``map u atTop ≤ 𝓝 x₀`` 成立。这个不等式意味着在 “``u`` 作用下”的“非常大的自然数集合”的“直接像”包含在“非常接近 ``x₀`` 的点的集合”中。
+
+-- As promised, the definition of ``Tendsto₂`` does not exhibit any quantifiers or sets.
+-- It also leverages the algebraic properties of the pushforward operation.
+-- First, each ``Filter.map f`` is monotone. And, second, ``Filter.map`` is compatible with
+-- composition.
+
+正如所承诺的那样，``Tendsto₂`` 的定义中没有任何量词或集合。
+它还利用了前推操作的代数性质。
+首先，每个 ``Filter.map f`` 都是单调的。其次，``Filter.map`` 与复合运算兼容。
 EXAMPLES: -/
 -- QUOTE:
 #check (@Filter.map_mono : ∀ {α β} {m : α → β}, Monotone (map m))
@@ -174,12 +226,15 @@ EXAMPLES: -/
 -- QUOTE.
 
 /- TEXT:
-Together these two properties allow us to prove that limits compose, yielding in one shot all 256 variants
-of the composition lemma described in the introduction, and lots more.
-You can practice proving the following statement using either the definition
-of ``Tendsto₁`` in terms of the
-universal quantifier or the algebraic definition,
-together with the two lemmas above.
+-- Together these two properties allow us to prove that limits compose, yielding in one shot all 256 variants
+-- of the composition lemma described in the introduction, and lots more.
+-- You can practice proving the following statement using either the definition
+-- of ``Tendsto₁`` in terms of the
+-- universal quantifier or the algebraic definition,
+-- together with the two lemmas above.
+
+这两个性质结合起来使我们能够证明极限的复合性，从而一次性得出引言中描述的 256 种组合引理变体，以及更多。
+您可以使用``Tendsto₁``的全称量词定义或代数定义，连同上述两个引理，来练习证明以下陈述。
 EXAMPLES: -/
 -- QUOTE:
 example {X Y Z : Type*} {F : Filter X} {G : Filter Y} {H : Filter Z} {f : X → Y} {g : Y → Z}
@@ -205,23 +260,35 @@ example {X Y Z : Type*} {F : Filter X} {G : Filter Y} {H : Filter Z} {f : X → 
   exact hV
 
 /- TEXT:
-The pushforward construction uses a map to push filters from the map source to the map target.
-There also a *pullback* operation, ``Filter.comap``, going in the other direction.
-This generalizes the
-preimage operation on sets. For any map ``f``,
-``Filter.map f`` and ``Filter.comap f`` form what is known as a *Galois connection*,
-which is to say, they satisfy
+-- The pushforward construction uses a map to push filters from the map source to the map target.
+-- There also a *pullback* operation, ``Filter.comap``, going in the other direction.
+-- This generalizes the
+-- preimage operation on sets. For any map ``f``,
+-- ``Filter.map f`` and ``Filter.comap f`` form what is known as a *Galois connection*,
+-- which is to say, they satisfy
 
-  ``Filter.map_le_iff_le_comap : Filter.map f F ≤ G ↔ F ≤ Filter.comap f G``
+--   ``Filter.map_le_iff_le_comap : Filter.map f F ≤ G ↔ F ≤ Filter.comap f G``
 
-for every ``F`` and ``G``.
-This operation could be used to provided another formulation of ``Tendsto`` that would be provably
-(but not definitionally) equivalent to the one in Mathlib.
+-- for every ``F`` and ``G``.
+-- This operation could be used to provided another formulation of ``Tendsto`` that would be provably
+-- (but not definitionally) equivalent to the one in Mathlib.
 
-The ``comap`` operation can be used to restrict filters to a subtype. For instance, suppose we have ``f : ℝ → ℝ``,
-``x₀ : ℝ`` and ``y₀ : ℝ``, and suppose we want to state that ``f x`` approaches ``y₀`` when ``x`` approaches ``x₀`` within the rational numbers.
-We can pull the filter ``𝓝 x₀`` back to ``ℚ`` using the coercion map
-``(↑) : ℚ → ℝ`` and state ``Tendsto (f ∘ (↑) : ℚ → ℝ) (comap (↑) (𝓝 x₀)) (𝓝 y₀)``.
+-- The ``comap`` operation can be used to restrict filters to a subtype. For instance, suppose we have ``f : ℝ → ℝ``,
+-- ``x₀ : ℝ`` and ``y₀ : ℝ``, and suppose we want to state that ``f x`` approaches ``y₀`` when ``x`` approaches ``x₀`` within the rational numbers.
+-- We can pull the filter ``𝓝 x₀`` back to ``ℚ`` using the coercion map
+-- ``(↑) : ℚ → ℝ`` and state ``Tendsto (f ∘ (↑) : ℚ → ℝ) (comap (↑) (𝓝 x₀)) (𝓝 y₀)``.
+
+前推构造使用一个映射将滤子从映射源推送到映射目标。
+还有一个“拉回”操作，即 ``Filter.comap`` ，其方向相反。
+这推广了集合上的原像操作。对于任何映射 ``f`` ，
+``Filter.map f`` 和 ``Filter.comap f`` 构成了所谓的**伽罗瓦连接**，也就是说，它们满足
+
+``filter.map_le_iff_le_comap``：``f`` 映射下的 ``F`` 小于等于 ``G`` 当且仅当 ``F`` 小于等于 ``G`` 在 ``f`` 下的逆像。
+
+对于每一个``F``和``G``。
+此操作可用于提供“Tendsto”的另一种表述形式，该形式可证明（但不是定义上）等同于 Mathlib 中的那个。
+
+``comap`` 操作可用于将滤子限制在子类型上。例如，假设我们有 ``f ： ℝ → ℝ``、``x₀ ： ℝ`` 和 ``y₀ ： ℝ``，并且假设我们想要说明当 ``x`` 在有理数范围内趋近于 ``x₀`` 时，``f x`` 趋近于 ``y₀``。我们可以使用强制转换映射 ``(↑) ： ℚ → ℝ`` 将滤子 ``𝓝 x₀`` 拉回到 ``ℚ``，并声明 ``Tendsto (f ∘ (↑) ： ℚ → ℝ) (comap (↑) (𝓝 x₀)) (𝓝 y₀)``。
 EXAMPLES: -/
 -- QUOTE:
 variable (f : ℝ → ℝ) (x₀ y₀ : ℝ)
@@ -232,8 +299,10 @@ variable (f : ℝ → ℝ) (x₀ y₀ : ℝ)
 -- QUOTE.
 
 /- TEXT:
-The pullback operation is also compatible with composition, but it is *contravariant*,
-which is to say, it reverses the order of the arguments.
+-- The pullback operation is also compatible with composition, but it is *contravariant*,
+-- which is to say, it reverses the order of the arguments.
+
+拉回操作也与复合运算兼容，但它具有**反变性**，也就是说，它会颠倒参数的顺序。
 EXAMPLES: -/
 -- QUOTE:
 section
@@ -245,9 +314,12 @@ end
 -- QUOTE.
 
 /- TEXT:
-Let's now shift attention to the plane ``ℝ × ℝ`` and try to understand how the neighborhoods of a point
-``(x₀, y₀)`` are related to ``𝓝 x₀`` and ``𝓝 y₀``. There is a product operation
-``Filter.prod : Filter X → Filter Y → Filter (X × Y)``, denoted by ``×ˢ``, which answers this question:
+-- Let's now shift attention to the plane ``ℝ × ℝ`` and try to understand how the neighborhoods of a point
+-- ``(x₀, y₀)`` are related to ``𝓝 x₀`` and ``𝓝 y₀``. There is a product operation
+-- ``Filter.prod : Filter X → Filter Y → Filter (X × Y)``, denoted by ``×ˢ``, which answers this question:
+
+现在让我们将注意力转向平面``ℝ × ℝ``，并尝试理解点``(x₀， y₀)``的邻域与``𝓝 x₀``和``𝓝 y₀``之间的关系。
+存在一个乘积运算``Filter.prod ： Filter X → Filter Y → Filter (X × Y)``，记作``×ˢ``，它回答了这个问题：
 EXAMPLES: -/
 -- QUOTE:
 example : 𝓝 (x₀, y₀) = 𝓝 x₀ ×ˢ 𝓝 y₀ :=
@@ -255,18 +327,27 @@ example : 𝓝 (x₀, y₀) = 𝓝 x₀ ×ˢ 𝓝 y₀ :=
 -- QUOTE.
 
 /- TEXT:
-The product operation is defined in terms of the pullback operation and the ``inf`` operation:
+-- The product operation is defined in terms of the pullback operation and the ``inf`` operation:
 
-  ``F ×ˢ G = (comap Prod.fst F) ⊓ (comap Prod.snd G)``.
+--   ``F ×ˢ G = (comap Prod.fst F) ⊓ (comap Prod.snd G)``.
 
-Here the ``inf`` operation refers to the lattice structure on ``Filter X`` for any type ``X``, whereby
-``F ⊓ G`` is the greatest filter that is smaller than both ``F`` and ``G``.
-Thus the ``inf`` operation generalizes the notion of the intersection of sets.
+-- Here the ``inf`` operation refers to the lattice structure on ``Filter X`` for any type ``X``, whereby
+-- ``F ⊓ G`` is the greatest filter that is smaller than both ``F`` and ``G``.
+-- Thus the ``inf`` operation generalizes the notion of the intersection of sets.
 
-A lot of proofs in Mathlib use all of the aforementioned structure (``map``, ``comap``, ``inf``, ``sup``, and ``prod``)
-to give algebraic proofs about convergence without ever referring to members of filters.
-You can practice doing this in a proof of the following lemma, unfolding the definition of ``Tendsto``
-and ``Filter.prod`` if needed.
+-- A lot of proofs in Mathlib use all of the aforementioned structure (``map``, ``comap``, ``inf``, ``sup``, and ``prod``)
+-- to give algebraic proofs about convergence without ever referring to members of filters.
+-- You can practice doing this in a proof of the following lemma, unfolding the definition of ``Tendsto``
+-- and ``Filter.prod`` if needed.
+
+该乘积运算通过拉回运算和``inf``运算来定义：
+
+``F ×ˢ G = (comap Prod.fst F) ⊓ (comap Prod.snd G)``
+
+这里的``inf``操作指的是对于任何类型 X 的``Filter X``上的格结构，其中 ``F ⊓ G`` 是小于 ``F`` 和 ``G`` 的最大滤子。
+因此，``inf``操作推广了集合交集的概念。
+
+在 Mathlib 中的许多证明都使用了上述所有结构（``map``、``comap``、``inf``、``sup`` 和 ``prod``），从而给出关于收敛性的代数证明，而无需提及滤子的成员。您可以在以下引理的证明中练习这样做，如果需要，可以展开 ``Tendsto`` 和 ``Filter.prod`` 的定义。
 EXAMPLES: -/
 -- QUOTE:
 #check le_inf_iff
@@ -292,7 +373,9 @@ example (f : ℕ → ℝ × ℝ) (x₀ y₀ : ℝ) :
       rw [map_map, map_map]
 
 
--- an alternative solution
+-- -- an alternative solution
+
+-- 一种备选方案
 example (f : ℕ → ℝ × ℝ) (x₀ y₀ : ℝ) :
     Tendsto f atTop (𝓝 (x₀, y₀)) ↔
       Tendsto (Prod.fst ∘ f) atTop (𝓝 x₀) ∧ Tendsto (Prod.snd ∘ f) atTop (𝓝 y₀) := by
@@ -301,61 +384,77 @@ example (f : ℕ → ℝ × ℝ) (x₀ y₀ : ℝ) :
   rw [le_inf_iff, ← map_le_iff_le_comap, map_map, ← map_le_iff_le_comap, map_map]
 
 /- TEXT:
-The ordered type ``Filter X`` is actually a *complete* lattice,
-which is to say, there is a bottom element, there is a top element, and
-every set of filters on ``X`` has an ``Inf`` and a ``Sup``.
+-- The ordered type ``Filter X`` is actually a *complete* lattice,
+-- which is to say, there is a bottom element, there is a top element, and
+-- every set of filters on ``X`` has an ``Inf`` and a ``Sup``.
 
-Note that given the second property in the definition of a filter
-(if ``U`` belongs to ``F`` then anything larger than ``U`` also belongs to ``F``),
-the first property
-(the set of all inhabitants of ``X`` belongs to ``F``) is
-equivalent to the property that ``F`` is not the empty collection of sets.
-This shouldn't be confused with the more subtle question as to whether
-the empty set is an *element* of ``F``. The
-definition of a filter does not prohibit ``∅ ∈ F``,
-but if the empty set is in ``F`` then
-every set is in ``F``, which is to say, ``∀ U : Set X, U ∈ F``.
-In this case, ``F`` is a rather trivial filter, which is precisely the
-bottom element of the complete lattice ``Filter X``.
-This contrasts with the definition of filters in
-Bourbaki, which doesn't allow filters containing the empty set.
+有序类型``Filter X``实际上是一个**完备**格，也就是说，存在一个最小元素，存在一个最大元素，并且 X 上的每个滤子集都有一个``Inf``和一个``Sup``。
 
-Because we include the trivial filter in our definition, we sometimes need to explicitly assume
-nontriviality in some lemmas.
-In return, however, the theory has nicer global properties.
-We have already seen that including the trivial filter gives us a
-bottom element. It also allows us to define ``principal : Set X → Filter X``,
-which maps  ``∅`` to ``⊥``, without adding a precondition to rule out the empty set.
-And it allows us to define the pullback operation without a precondition as well.
-Indeed, it can happen that ``comap f F = ⊥`` although ``F ≠ ⊥``. For instance,
-given ``x₀ : ℝ`` and ``s : Set ℝ``, the pullback of ``𝓝 x₀`` under the coercion
-from the subtype corresponding to ``s`` is nontrivial if and only if ``x₀`` belongs to the
-closure of ``s``.
+-- Note that given the second property in the definition of a filter
+-- (if ``U`` belongs to ``F`` then anything larger than ``U`` also belongs to ``F``),
+-- the first property
+-- (the set of all inhabitants of ``X`` belongs to ``F``) is
+-- equivalent to the property that ``F`` is not the empty collection of sets.
+-- This shouldn't be confused with the more subtle question as to whether
+-- the empty set is an *element* of ``F``. The
+-- definition of a filter does not prohibit ``∅ ∈ F``,
+-- but if the empty set is in ``F`` then
+-- every set is in ``F``, which is to say, ``∀ U : Set X, U ∈ F``.
+-- In this case, ``F`` is a rather trivial filter, which is precisely the
+-- bottom element of the complete lattice ``Filter X``.
+-- This contrasts with the definition of filters in
+-- Bourbaki, which doesn't allow filters containing the empty set.
 
-In order to manage lemmas that do need to assume some filter is nontrivial, Mathlib has
-a type class ``Filter.NeBot``, and the library has lemmas that assume
-``(F : Filter X) [F.NeBot]``. The instance database knows, for example, that ``(atTop : Filter ℕ).NeBot``,
-and it knows that pushing forward a nontrivial filter gives a nontrivial filter.
-As a result, a lemma assuming ``[F.NeBot]`` will automatically apply to ``map u atTop`` for any sequence ``u``.
+请注意，根据滤子定义中的第二个性质（如果``U``属于``F``，那么任何包含``U``的集合也属于``F``），第一个性质（``X``的所有元素组成的集合属于``F``）等价于``F``不是空集合这一性质。这不应与更微妙的问题相混淆，即空集是否为``F``的一个**元素**。滤子的定义并不禁止``∅ ∈ F``，但如果空集在``F``中，那么每个集合都在``F``中，也就是说，``∀ U : Set X, U ∈ F``。在这种情况下，``F``是一个相当平凡的滤子，恰好是完备格``Filter X``的最小元素。这与布尔巴基对滤子的定义形成对比，布尔巴基的定义不允许滤子包含空集。
 
-Our tour of the algebraic properties of filters and their relation to limits is essentially done,
-but we have not yet justified our claim to have recaptured the usual limit notions.
-Superficially, it may seem that ``Tendsto u atTop (𝓝 x₀)``
-is stronger than the notion of convergence defined in :numref:`sequences_and_convergence` because we ask that *every* neighborhood of ``x₀``
-has a preimage belonging to ``atTop``, whereas the usual definition only requires
-this for the standard neighborhoods ``Ioo (x₀ - ε) (x₀ + ε)``.
-The key is that, by definition, every neighborhood contains such a standard one.
-This observation leads to the notion of a *filter basis*.
+-- Because we include the trivial filter in our definition, we sometimes need to explicitly assume
+-- nontriviality in some lemmas.
+-- In return, however, the theory has nicer global properties.
+-- We have already seen that including the trivial filter gives us a
+-- bottom element. It also allows us to define ``principal : Set X → Filter X``,
+-- which maps  ``∅`` to ``⊥``, without adding a precondition to rule out the empty set.
+-- And it allows us to define the pullback operation without a precondition as well.
+-- Indeed, it can happen that ``comap f F = ⊥`` although ``F ≠ ⊥``. For instance,
+-- given ``x₀ : ℝ`` and ``s : Set ℝ``, the pullback of ``𝓝 x₀`` under the coercion
+-- from the subtype corresponding to ``s`` is nontrivial if and only if ``x₀`` belongs to the
+-- closure of ``s``.
 
-Given ``F : Filter X``,
-a family of sets ``s : ι → Set X`` is a basis for ``F`` if for every set ``U``,
-we have ``U ∈ F`` if and only if it contains some ``s i``. In other words, formally speaking,
-``s`` is a basis if it satisfies
-``∀ U : Set X, U ∈ F ↔ ∃ i, s i ⊆ U``. It is even more flexible to consider
-a predicate on ``ι`` that selects only some of the values ``i`` in the indexing type.
-In the case of ``𝓝 x₀``, we want ``ι`` to be ``ℝ``, we write ``ε`` for ``i``, and the predicate should select the positive values of ``ε``.
-So the fact that the sets ``Ioo  (x₀ - ε) (x₀ + ε)`` form a basis for the
-neighborhood topology on ``ℝ`` is stated as follows:
+由于我们在定义中包含了平凡滤子，所以在某些引理中有时需要明确假设非平凡性。不过作为回报，该理论具有更优的整体性质。我们已经看到，包含平凡滤子为我们提供了一个最小元素。它还允许我们定义``principal ： Set X → Filter X``，将``∅``映射到``⊥``，而无需添加预条件来排除空集。而且它还允许我们定义拉回操作时无需预条件。实际上，有可能``comap f F = ⊥``尽管``F ≠ ⊥``。例如，给定``x₀ ： ℝ``和``s : Set ℝ``，``𝓝 x₀``在从与``s``对应的子类型强制转换下的拉回非平凡当且仅当``x₀``属于``s``的闭包。
+
+-- In order to manage lemmas that do need to assume some filter is nontrivial, Mathlib has
+-- a type class ``Filter.NeBot``, and the library has lemmas that assume
+-- ``(F : Filter X) [F.NeBot]``. The instance database knows, for example, that ``(atTop : Filter ℕ).NeBot``,
+-- and it knows that pushing forward a nontrivial filter gives a nontrivial filter.
+-- As a result, a lemma assuming ``[F.NeBot]`` will automatically apply to ``map u atTop`` for any sequence ``u``.
+
+为了管理确实需要假设某些滤子非平凡的引理，Mathlib 设有类型类``Filter.NeBot``，并且库中存在假设``（F : Filter X）[F.NeBot]``的引理。实例数据库知道，例如，``(atTop : Filter ℕ).NeBot``，并且知道将非平凡滤子向前推进会得到一个非平凡滤子。因此，假设``[F.NeBot]``的引理将自动应用于任何序列``u``的``map u atTop``。
+
+-- Our tour of the algebraic properties of filters and their relation to limits is essentially done,
+-- but we have not yet justified our claim to have recaptured the usual limit notions.
+-- Superficially, it may seem that ``Tendsto u atTop (𝓝 x₀)``
+-- is stronger than the notion of convergence defined in :numref:`sequences_and_convergence` because we ask that *every* neighborhood of ``x₀``
+-- has a preimage belonging to ``atTop``, whereas the usual definition only requires
+-- this for the standard neighborhoods ``Ioo (x₀ - ε) (x₀ + ε)``.
+-- The key is that, by definition, every neighborhood contains such a standard one.
+-- This observation leads to the notion of a *filter basis*.
+
+
+我们对滤子的代数性质及其与极限的关系的探讨基本上已经完成，但我们尚未证明我们所提出的重新捕捉通常极限概念的主张是合理的。
+表面上看，``Tendsto u atTop (𝓝 x₀)``似乎比在 :numref:``sequences_and_convergence`` 中定义的收敛概念更强，因为我们要求``x₀``的**每个**邻域都有一个属于``atTop``的原像，而通常的定义仅要求对于标准邻域``Ioo (x₀ - ε) (x₀ + ε)``满足这一条件。关键在于，根据定义，每个邻域都包含这样的标准邻域。这一观察引出了**滤子基（filter basis）**的概念。
+
+-- Given ``F : Filter X``,
+-- a family of sets ``s : ι → Set X`` is a basis for ``F`` if for every set ``U``,
+-- we have ``U ∈ F`` if and only if it contains some ``s i``. In other words, formally speaking,
+-- ``s`` is a basis if it satisfies
+-- ``∀ U : Set X, U ∈ F ↔ ∃ i, s i ⊆ U``. It is even more flexible to consider
+-- a predicate on ``ι`` that selects only some of the values ``i`` in the indexing type.
+-- In the case of ``𝓝 x₀``, we want ``ι`` to be ``ℝ``, we write ``ε`` for ``i``, and the predicate should select the positive values of ``ε``.
+-- So the fact that the sets ``Ioo  (x₀ - ε) (x₀ + ε)`` form a basis for the
+-- neighborhood topology on ``ℝ`` is stated as follows:
+
+给定``F : Filter X``，如果对于每个集合``U``，我们有``U ∈ F``当且仅当它包含某个``s i``，那么集合族``s ： ι → Set X``就是``F``的基。
+换句话说，严格说来，``s``是基当且仅当它满足``∀ U : Set X, U ∈ F ↔ ∃ i, s i ⊆ U``。考虑在索引类型中仅选择某些值``i``的``ι``上的谓词会更加灵活。
+对于``𝓝 x₀``，我们希望``ι``为``ℝ``，用``ε``表示``i``，并且谓词应选择``ε``的正值。因此，集合``Ioo (x₀ - ε) (x₀ + ε)``构成``ℝ``上邻域拓扑的基这一事实可表述如下：
 EXAMPLES: -/
 -- QUOTE:
 example (x₀ : ℝ) : HasBasis (𝓝 x₀) (fun ε : ℝ ↦ 0 < ε) fun ε ↦ Ioo (x₀ - ε) (x₀ + ε) :=
@@ -363,12 +462,14 @@ example (x₀ : ℝ) : HasBasis (𝓝 x₀) (fun ε : ℝ ↦ 0 < ε) fun ε ↦
 -- QUOTE.
 
 /- TEXT:
-There is also a nice basis for the filter ``atTop``. The lemma
-``Filter.HasBasis.tendsto_iff`` allows
-us to reformulate a statement of the form ``Tendsto f F G``
-given bases for ``F`` and ``G``.
-Putting these pieces together gives us essentially the notion of convergence
-that we used in :numref:`sequences_and_convergence`.
+-- There is also a nice basis for the filter ``atTop``. The lemma
+-- ``Filter.HasBasis.tendsto_iff`` allows
+-- us to reformulate a statement of the form ``Tendsto f F G``
+-- given bases for ``F`` and ``G``.
+-- Putting these pieces together gives us essentially the notion of convergence
+-- that we used in :numref:`sequences_and_convergence`.
+
+还有一个很好的``atTop``滤子的基础。引理``Filter.HasBasis.tendsto_iff``允许我们在给定``F``和``G``的基础的情况下，重新表述形式为``Tendsto f F G``的陈述。将这些部分组合在一起，就基本上得到了我们在 :numref:``sequences_and_convergence`` 中使用的收敛概念。
 EXAMPLES: -/
 -- QUOTE:
 example (u : ℕ → ℝ) (x₀ : ℝ) :
@@ -379,24 +480,28 @@ example (u : ℕ → ℝ) (x₀ : ℝ) :
 -- QUOTE.
 
 /- TEXT:
-We now show how filters facilitate working with properties that hold for sufficiently large numbers
-or for points that are sufficiently close to a given point. In :numref:`sequences_and_convergence`, we were often faced with the situation where
-we knew that some property ``P n`` holds for sufficiently large ``n`` and that some
-other property ``Q n`` holds for sufficiently large ``n``.
-Using ``cases`` twice gave us ``N_P`` and ``N_Q`` satisfying
-``∀ n ≥ N_P, P n`` and ``∀ n ≥ N_Q, Q n``. Using ``set N := max N_P N_Q``, we could
-eventually prove ``∀ n ≥ N, P n ∧ Q n``.
-Doing this repeatedly becomes tiresome.
+-- We now show how filters facilitate working with properties that hold for sufficiently large numbers
+-- or for points that are sufficiently close to a given point. In :numref:`sequences_and_convergence`, we were often faced with the situation where
+-- we knew that some property ``P n`` holds for sufficiently large ``n`` and that some
+-- other property ``Q n`` holds for sufficiently large ``n``.
+-- Using ``cases`` twice gave us ``N_P`` and ``N_Q`` satisfying
+-- ``∀ n ≥ N_P, P n`` and ``∀ n ≥ N_Q, Q n``. Using ``set N := max N_P N_Q``, we could
+-- eventually prove ``∀ n ≥ N, P n ∧ Q n``.
+-- Doing this repeatedly becomes tiresome.
 
-We can do better by noting that the statement "``P n`` and ``Q n`` hold for large enough ``n``" means
-that we have ``{n | P n} ∈ atTop`` and ``{n | Q n} ∈ atTop``.
-The fact that ``atTop`` is a filter implies that the intersection of two elements of ``atTop``
-is again in ``atTop``, so we have ``{n | P n ∧ Q n} ∈ atTop``.
-Writing ``{n | P n} ∈ atTop`` is unpleasant,
-but we can use the more suggestive notation ``∀ᶠ n in atTop, P n``.
-Here the superscripted ``f`` stands for "Filter."
-You can think of the notation as saying that for all ``n`` in the "set of very large numbers," ``P n`` holds. The ``∀ᶠ``
-notation stands for ``Filter.Eventually``, and the lemma ``Filter.Eventually.and`` uses the intersection property of filters to do what we just described:
+现在我们展示一下滤子如何有助于处理对于足够大的数字或对于给定点足够近的点成立的性质。在 :numref:`sequences_and_convergence` 中，我们经常遇到这样的情况：我们知道某个性质 ``P n`` 对于足够大的 ``n`` 成立，而另一个性质 ``Q n`` 对于足够大的 ``n`` 也成立。使用两次 ``cases`` 得到了满足 ``∀ n ≥ N_P， P n`` 和 ``∀ n ≥ N_Q， Q n`` 的 ``N_P`` 和 ``N_Q``。通过 ``set N := max N_P N_Q``，我们最终能够证明 ``∀ n ≥ N， P n ∧ Q n``。反复这样做会让人感到厌烦。
+
+-- We can do better by noting that the statement "``P n`` and ``Q n`` hold for large enough ``n``" means
+-- that we have ``{n | P n} ∈ atTop`` and ``{n | Q n} ∈ atTop``.
+-- The fact that ``atTop`` is a filter implies that the intersection of two elements of ``atTop``
+-- is again in ``atTop``, so we have ``{n | P n ∧ Q n} ∈ atTop``.
+-- Writing ``{n | P n} ∈ atTop`` is unpleasant,
+-- but we can use the more suggestive notation ``∀ᶠ n in atTop, P n``.
+-- Here the superscripted ``f`` stands for "Filter."
+-- You can think of the notation as saying that for all ``n`` in the "set of very large numbers," ``P n`` holds. The ``∀ᶠ``
+-- notation stands for ``Filter.Eventually``, and the lemma ``Filter.Eventually.and`` uses the intersection property of filters to do what we just described:
+
+我们可以通过注意到“对于足够大的 n，``P n`` 和 ``Q n`` 成立”这一表述意味着我们有 ``{n | P n} ∈ atTop`` 和 ``{n | Q n} ∈ atTop`` 来做得更好。由于 ``atTop`` 是一个滤子，所以 ``atTop`` 中两个元素的交集仍在 ``atTop`` 中，因此我们有 ``{n | P n ∧ Q n} ∈ atTop``。书写 ``{n | P n} ∈ atTop`` 不太美观，但我们可以用更具提示性的记号 ``∀ᶠ n in atTop， P n``。这里的上标 ``f`` 表示“滤子”。你可以将这个记号理解为对于“非常大的数集”中的所有 ``n``，``P n`` 成立。``∀ᶠ`` 记号代表 ``Filter.Eventually``，而引理 ``Filter.Eventually.and`` 利用滤子的交集性质来实现我们刚才所描述的操作：
 EXAMPLES: -/
 -- QUOTE:
 example (P Q : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in atTop, Q n) :
@@ -405,14 +510,16 @@ example (P Q : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in atT
 -- QUOTE.
 
 /- TEXT:
-This notation is so convenient and intuitive that we also have specializations
-when ``P`` is an equality or inequality statement. For example, let ``u`` and ``v`` be
-two sequences of real numbers, and let us show that if
-``u n`` and ``v n`` coincide for sufficiently large ``n`` then
-``u`` tends to ``x₀`` if and only if ``v`` tends to ``x₀``.
-First we'll use the generic ``Eventually`` and then the one
-specialized for the equality predicate, ``EventuallyEq``. The two statements are
-definitionally equivalent so the same proof work in both cases.
+-- This notation is so convenient and intuitive that we also have specializations
+-- when ``P`` is an equality or inequality statement. For example, let ``u`` and ``v`` be
+-- two sequences of real numbers, and let us show that if
+-- ``u n`` and ``v n`` coincide for sufficiently large ``n`` then
+-- ``u`` tends to ``x₀`` if and only if ``v`` tends to ``x₀``.
+-- First we'll use the generic ``Eventually`` and then the one
+-- specialized for the equality predicate, ``EventuallyEq``. The two statements are
+-- definitionally equivalent so the same proof work in both cases.
+
+这种表示法如此方便且直观，以至于当``P``是一个等式或不等式陈述时，我们也有专门的表示形式。例如，设``u``和``v``是两个实数序列，让我们证明如果对于足够大的``n``，``u n``和``v n``相等，那么``u``趋向于``x₀``当且仅当``v``趋向于``x₀``。首先我们将使用通用的``Eventually``，然后使用专门针对等式谓词的``EventuallyEq``。这两个陈述在定义上是等价的，因此在两种情况下相同的证明都适用。
 EXAMPLES: -/
 -- QUOTE:
 example (u v : ℕ → ℝ) (h : ∀ᶠ n in atTop, u n = v n) (x₀ : ℝ) :
@@ -425,12 +532,19 @@ example (u v : ℕ → ℝ) (h : u =ᶠ[atTop] v) (x₀ : ℝ) :
 -- QUOTE.
 
 /- TEXT:
-It is instructive to review the definition of filters in terms of ``Eventually``.
-Given ``F : Filter X``, for any predicates ``P`` and ``Q`` on ``X``,
+-- It is instructive to review the definition of filters in terms of ``Eventually``.
+-- Given ``F : Filter X``, for any predicates ``P`` and ``Q`` on ``X``,
 
-* the condition ``univ ∈ F`` ensures ``(∀ x, P x) → ∀ᶠ x in F, P x``,
-* the condition ``U ∈ F → U ⊆ V → V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ x, P x → Q x) → ∀ᶠ x in F, Q x``, and
-* the condition ``U ∈ F → V ∈ F → U ∩ V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ᶠ x in F, Q x) → ∀ᶠ x in F, P x ∧ Q x``.
+-- * the condition ``univ ∈ F`` ensures ``(∀ x, P x) → ∀ᶠ x in F, P x``,
+-- * the condition ``U ∈ F → U ⊆ V → V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ x, P x → Q x) → ∀ᶠ x in F, Q x``, and
+-- * the condition ``U ∈ F → V ∈ F → U ∩ V ∈ F`` ensures ``(∀ᶠ x in F, P x) → (∀ᶠ x in F, Q x) → ∀ᶠ x in F, P x ∧ Q x``.
+
+从``Eventually``这一概念的角度来审视滤子的定义是很有启发性的。
+给定滤子 ``F : Filter X`` ，对于 ``X`` 上的任意谓词 ``P`` 和 ``Q`` ，
+
+条件``univ ∈ F``确保了``(∀ x, P x) → ∀ᶠ x in F, P x``，
+条件``U ∈ F → U ⊆ V → V ∈ F``确保了``(∀ᶠ x in F, P x) → (∀ x, P x → Q x) → ∀ᶠ x in F, Q x``，并且
+条件``U ∈ F → V ∈ F → U ∩ V ∈ F``确保了``(∀ᶠ x in F, P x) → (∀ᶠ x in F, Q x) → ∀ᶠ x in F, P x ∧ Q x``。
 EXAMPLES: -/
 -- QUOTE:
 #check Eventually.of_forall
@@ -439,10 +553,12 @@ EXAMPLES: -/
 -- QUOTE.
 
 /- TEXT:
-The second item, corresponding to ``Eventually.mono``, supports nice ways
-of using filters, especially when combined
-with ``Eventually.and``. The ``filter_upwards`` tactic allows us to combine them.
-Compare:
+-- The second item, corresponding to ``Eventually.mono``, supports nice ways
+-- of using filters, especially when combined
+-- with ``Eventually.and``. The ``filter_upwards`` tactic allows us to combine them.
+-- Compare:
+
+第二个项目，对应于``Eventually.mono``，支持使用滤子的优雅方式，尤其是与``Eventually.and``结合使用时。``filter_upwards`` 策略使我们能够将它们组合起来。比较：
 EXAMPLES: -/
 -- QUOTE:
 example (P Q R : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in atTop, Q n)
@@ -458,30 +574,53 @@ example (P Q R : ℕ → Prop) (hP : ∀ᶠ n in atTop, P n) (hQ : ∀ᶠ n in a
 -- QUOTE.
 
 /- TEXT:
-Readers who know about measure theory will note that the filter ``μ.ae`` of sets whose complement has measure zero
-(aka "the set consisting of almost every point") is not very useful as the source or target of ``Tendsto``, but it can be conveniently
-used with ``Eventually`` to say that a property holds for almost every point.
+-- Readers who know about measure theory will note that the filter ``μ.ae`` of sets whose complement has measure zero
+-- (aka "the set consisting of almost every point") is not very useful as the source or target of ``Tendsto``, but it can be conveniently
+-- used with ``Eventually`` to say that a property holds for almost every point.
 
-There is a dual version of ``∀ᶠ x in F, P x``, which is occasionally useful:
-``∃ᶠ x in F, P x`` means
-``{x | ¬P x} ∉ F``. For example, ``∃ᶠ n in atTop, P n`` means there are arbitrarily large ``n`` such that ``P n`` holds.
-The ``∃ᶠ`` notation stands for ``Filter.Frequently``.
+熟悉测度论的读者会注意到，补集测度为零的集合构成的滤子``μ.ae``（即“几乎每个点构成的集合”）作为``Tendsto``的源或目标并不是很有用，但它可以方便地与``Eventually``一起使用，以表明某个性质对几乎每个点都成立。
 
-For a more sophisticated example, consider the following statement about a sequence
-``u``, a set ``M``, and a value ``x``:
+-- There is a dual version of ``∀ᶠ x in F, P x``, which is occasionally useful:
+-- ``∃ᶠ x in F, P x`` means
+-- ``{x | ¬P x} ∉ F``. For example, ``∃ᶠ n in atTop, P n`` means there are arbitrarily large ``n`` such that ``P n`` holds.
+-- The ``∃ᶠ`` notation stands for ``Filter.Frequently``.
 
-  If ``u`` converges to ``x`` and ``u n`` belongs to ``M`` for
-  sufficiently large ``n`` then ``x`` is in the closure of ``M``.
+-- There is a dual version of ``∀ᶠ x in F, P x``, which is occasionally useful:
+-- ``∃ᶠ x in F, P x`` means
+-- ``{x | ¬P x} ∉ F``. For example, ``∃ᶠ n in atTop, P n`` means there are arbitrarily large ``n`` such that ``P n`` holds.
+-- The ``∃ᶠ`` notation stands for ``Filter.Frequently``.
 
-This can be formalized as follows:
+存在``∀ᶠ x in F, P x``的双重版本，有时会很有用：
+用``∃ᶠ x in F, P x``表示
+``{x | ¬P x} ∉ F``。例如，``∃ᶠ n in atTop, P n``意味着存在任意大的 ``n`` 使得 ``P n`` 成立。
+``∃ᶠ``符号代表``Filter.Frequently``。
+
+-- For a more sophisticated example, consider the following statement about a sequence
+-- ``u``, a set ``M``, and a value ``x``:
+
+对于一个更复杂的示例，请考虑以下关于序列 ``u``、集合 ``M`` 和值 ``x`` 的陈述：
+
+  -- If ``u`` converges to ``x`` and ``u n`` belongs to ``M`` for
+  -- sufficiently large ``n`` then ``x`` is in the closure of ``M``.
+
+如果序列 ``u`` 收敛于 ``x`` ，且对于足够大的 ``n`` ，``u n`` 属于集合 ``M`` ，那么 ``x`` 就在集合 ``M`` 的闭包内。
+
+-- This can be formalized as follows:
+
+--   ``Tendsto u atTop (𝓝 x) → (∀ᶠ n in atTop, u n ∈ M) → x ∈ closure M``.
+
+-- This is a special case of the theorem ``mem_closure_of_tendsto`` from the
+-- topology library.
+-- See if you can prove it using the quoted lemmas,
+-- using the fact that ``ClusterPt x F`` means ``(𝓝 x ⊓ F).NeBot`` and that,
+-- by definition, the assumption ``∀ᶠ n in atTop, u n ∈ M`` means  ``M ∈ map u atTop``.
+
+这可以形式化表述如下：
 
   ``Tendsto u atTop (𝓝 x) → (∀ᶠ n in atTop, u n ∈ M) → x ∈ closure M``.
 
-This is a special case of the theorem ``mem_closure_of_tendsto`` from the
-topology library.
-See if you can prove it using the quoted lemmas,
-using the fact that ``ClusterPt x F`` means ``(𝓝 x ⊓ F).NeBot`` and that,
-by definition, the assumption ``∀ᶠ n in atTop, u n ∈ M`` means  ``M ∈ map u atTop``.
+这是拓扑库中定理``mem_closure_of_tendsto``的一个特殊情况。
+试着利用所引用的引理来证明它，利用``ClusterPt x F``意味着``(𝓝 x ⊓ F).NeBot``这一事实，以及根据定义，``∀ᶠ n in atTop， u n ∈ M``这一假设意味着``M ∈ map u atTop``。
 EXAMPLES: -/
 -- QUOTE:
 #check mem_closure_iff_clusterPt

--- a/MIL/C10_Topology/S02_Metric_Spaces.lean
+++ b/MIL/C10_Topology/S02_Metric_Spaces.lean
@@ -10,14 +10,23 @@ open Topology Filter
 
 .. _metric_spaces:
 
-Metric spaces
+-- Metric spaces
+-- --------------
+
+-- Examples in the previous section focus on sequences of real numbers. In this section we will go up a bit in generality and focus on
+-- metric spaces. A metric space is a type ``X`` equipped with a distance function ``dist : X → X → ℝ`` which is a generalization of
+-- the function ``fun x y ↦ |x - y|`` from the case where ``X = ℝ``.
+
+-- Introducing such a space is easy and we will check all properties required from the distance function.
+
+度量空间
 --------------
 
-Examples in the previous section focus on sequences of real numbers. In this section we will go up a bit in generality and focus on
-metric spaces. A metric space is a type ``X`` equipped with a distance function ``dist : X → X → ℝ`` which is a generalization of
-the function ``fun x y ↦ |x - y|`` from the case where ``X = ℝ``.
 
-Introducing such a space is easy and we will check all properties required from the distance function.
+在上一节中的示例主要关注实数序列。在本节中，我们将提高一点一般性，关注度量空间。
+度量空间是一种类型``X``，它配备了一个距离函数``dist : X → X → ℝ``，这是在``X = ℝ``情形下函数``fun x y ↦ |x - y|``的一种推广。
+
+引入这样一个空间很简单，我们将检验距离函数所需的所有性质。
 BOTH: -/
 -- QUOTE:
 variable {X : Type*} [MetricSpace X] (a b c : X)
@@ -30,25 +39,40 @@ variable {X : Type*} [MetricSpace X] (a b c : X)
 -- QUOTE.
 
 /- TEXT:
-Note we also have variants where the distance can be infinite or where ``dist a b`` can be zero without having ``a = b`` or both.
-They are called ``EMetricSpace``, ``PseudoMetricSpace`` and ``PseudoEMetricSpace`` respectively (here "e" stands for "extended").
+-- Note we also have variants where the distance can be infinite or where ``dist a b`` can be zero without having ``a = b`` or both.
+-- They are called ``EMetricSpace``, ``PseudoMetricSpace`` and ``PseudoEMetricSpace`` respectively (here "e" stands for "extended").
+
+
+请注意，我们还有其他变体，其中距离可以是无穷大，或者``dist a b``可以为零而不需要``a = b``或者两者皆是。
+它们分别被称为``EMetricSpace``、``PseudoMetricSpace``和``PseudoEMetricSpace``（这里“e”代表“扩展”）。
 
 BOTH: -/
--- Note the next three lines are not quoted, their purpose is to make sure those things don't get renamed while we're looking elsewhere.
+-- -- Note the next three lines are not quoted, their purpose is to make sure those things don't get renamed while we're looking elsewhere.
+
+-- 请注意接下来的三行未加引号，其目的是在我们查看其他内容时确保这些内容不会被重命名。
 #check EMetricSpace
 #check PseudoMetricSpace
 #check PseudoEMetricSpace
 
 /- TEXT:
-Note that our journey from ``ℝ`` to metric spaces jumped over the special case of normed spaces that also require linear algebra and
-will be explained as part of the calculus chapter.
+-- Note that our journey from ``ℝ`` to metric spaces jumped over the special case of normed spaces that also require linear algebra and
+-- will be explained as part of the calculus chapter.
 
-Convergence and continuity
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+-- Convergence and continuity
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using distance functions, we can already define convergent sequences and continuous functions between metric spaces.
-They are actually defined in a more general setting covered in the next section,
-but we have lemmas recasting the definition in terms of distances.
+-- Using distance functions, we can already define convergent sequences and continuous functions between metric spaces.
+-- They are actually defined in a more general setting covered in the next section,
+-- but we have lemmas recasting the definition in terms of distances.
+
+请注意，我们从实数集``ℝ``到度量空间的旅程跳过了需要线性代数知识的赋范空间这一特殊情况，这部分内容将在微积分章节中进行解释。
+
+收敛与连续性
+^^^^^^^^^^^
+
+利用距离函数，我们已经能够在度量空间之间定义收敛序列和连续函数。
+实际上，它们是在下一节所涵盖的更一般的情形中定义的，
+但我们有一些引理将定义重新表述为距离的形式。
 BOTH: -/
 -- QUOTE:
 example {u : ℕ → X} {a : X} :
@@ -65,12 +89,15 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} :
 .. index:: continuity, tactics ; continuity
 
 
-A *lot* of lemmas have some continuity assumptions, so we end up proving a lot of continuity results and there
-is a ``continuity`` tactic devoted to this task. Let's prove a continuity statement that will be needed
-in an exercise below. Notice that Lean knows how to treat a product of two metric spaces as a metric space, so
-it makes sense to consider continuous functions from ``X × X`` to ``ℝ``.
-In particular the (uncurried version of the) distance function is such a function.
+-- A *lot* of lemmas have some continuity assumptions, so we end up proving a lot of continuity results and there
+-- is a ``continuity`` tactic devoted to this task. Let's prove a continuity statement that will be needed
+-- in an exercise below. Notice that Lean knows how to treat a product of two metric spaces as a metric space, so
+-- it makes sense to consider continuous functions from ``X × X`` to ``ℝ``.
+-- In particular the (uncurried version of the) distance function is such a function.
 
+
+**很多**引理都有一些连续性假设，所以我们最终要证明很多连续性结果，并且有一个专门用于此任务的``连续性``策略。让我们证明一个连续性陈述，它将在下面的一个练习中用到。请注意，Lean 知道如何将两个度量空间的乘积视为一个度量空间，因此考虑从 ``X × X`` 到 ``ℝ`` 的连续函数是有意义的。
+特别是距离函数（未卷曲的版本）就是这样一种函数。
 BOTH: -/
 -- QUOTE:
 example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Continuous f) :
@@ -78,17 +105,19 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
-This tactic is a bit slow, so it is also useful to know
-how to do it by hand. We first need to use that ``fun p : X × X ↦ f p.1`` is continuous because it
-is the composition of ``f``, which is continuous by assumption ``hf``, and the projection ``prod.fst`` whose continuity
-is the content of the lemma ``continuous_fst``. The composition property is ``Continuous.comp`` which is
-in the ``Continuous`` namespace so we can use dot notation to compress
-``Continuous.comp hf continuous_fst`` into ``hf.comp continuous_fst`` which is actually more readable
-since it really reads as composing our assumption and our lemma.
-We can do the same for the second component to get continuity of ``fun p : X × X ↦ f p.2``. We then assemble
-those two continuities using ``Continuous.prod_mk`` to get
-``(hf.comp continuous_fst).prod_mk (hf.comp continuous_snd) : Continuous (fun p : X × X ↦ (f p.1, f p.2))``
-and compose once more to get our full proof.
+-- This tactic is a bit slow, so it is also useful to know
+-- how to do it by hand. We first need to use that ``fun p : X × X ↦ f p.1`` is continuous because it
+-- is the composition of ``f``, which is continuous by assumption ``hf``, and the projection ``prod.fst`` whose continuity
+-- is the content of the lemma ``continuous_fst``. The composition property is ``Continuous.comp`` which is
+-- in the ``Continuous`` namespace so we can use dot notation to compress
+-- ``Continuous.comp hf continuous_fst`` into ``hf.comp continuous_fst`` which is actually more readable
+-- since it really reads as composing our assumption and our lemma.
+-- We can do the same for the second component to get continuity of ``fun p : X × X ↦ f p.2``. We then assemble
+-- those two continuities using ``Continuous.prod_mk`` to get
+-- ``(hf.comp continuous_fst).prod_mk (hf.comp continuous_snd) : Continuous (fun p : X × X ↦ (f p.1, f p.2))``
+-- and compose once more to get our full proof.
+
+这种策略有点慢，所以了解如何手动操作也是有用的。我们首先需要利用``fun p : X × X ↦ f p.1``是连续的这一事实，因为它是连续函数 ``f``（由假设 ``hf`` 给出）与投影 ``prod.fst`` 的复合，而 ``prod.fst`` 的连续性正是引理 ``continuous_fst`` 的内容。复合性质是 ``Continuous.comp``，它在 ``Continuous`` 命名空间中，所以我们可以用点表示法将``Continuous.comp hf continuous_fst``压缩为``hf.comp continuous_fst``，这实际上更易读，因为它确实读作将我们的假设和引理进行复合。我们对第二个分量做同样的操作，以获得``fun p ： X × X ↦ f p.2``的连续性。然后，我们使用 ``Continuous.prod_mk`` 将这两个连续性组合起来，得到``(hf.comp continuous_fst).prod_mk (hf.comp continuous_snd) : Continuous (fun p : X × X ↦ (f p.1， f p.2))``，并再次复合以完成我们的完整证明。
 BOTH: -/
 -- QUOTE:
 example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Continuous f) :
@@ -97,20 +126,26 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
-The combination of ``Continuous.prod_mk`` and ``continuous_dist`` via ``Continuous.comp`` feels clunky,
-even when heavily using dot notation as above. A more serious issue is that this nice proof requires a lot of
-planning. Lean accepts the above proof term because it is a full term proving a statement which is
-definitionally equivalent to our goal, the crucial definition to unfold being that of a composition of functions.
-Indeed our target function ``fun p : X × X ↦ dist (f p.1) (f p.2)`` is not presented as a composition.
-The proof term we provided proves continuity of ``dist ∘ (fun p : X × X ↦ (f p.1, f p.2))`` which happens
-to be definitionally equal to our target function. But if we try to build this proof gradually using
-tactics starting with ``apply continuous_dist.comp`` then Lean's elaborator will fail to recognize a
-composition and refuse to apply this lemma. It is especially bad at this when products of types are involved.
+-- The combination of ``Continuous.prod_mk`` and ``continuous_dist`` via ``Continuous.comp`` feels clunky,
+-- even when heavily using dot notation as above. A more serious issue is that this nice proof requires a lot of
+-- planning. Lean accepts the above proof term because it is a full term proving a statement which is
+-- definitionally equivalent to our goal, the crucial definition to unfold being that of a composition of functions.
+-- Indeed our target function ``fun p : X × X ↦ dist (f p.1) (f p.2)`` is not presented as a composition.
+-- The proof term we provided proves continuity of ``dist ∘ (fun p : X × X ↦ (f p.1, f p.2))`` which happens
+-- to be definitionally equal to our target function. But if we try to build this proof gradually using
+-- tactics starting with ``apply continuous_dist.comp`` then Lean's elaborator will fail to recognize a
+-- composition and refuse to apply this lemma. It is especially bad at this when products of types are involved.
 
-A better lemma to apply here is
+通过 ``Continuous.comp`` 将 ``Continuous.prod_mk`` 和 ``continuous_dist`` 结合起来的方式感觉很笨拙，即便像上面那样大量使用点标记也是如此。更严重的问题在于，这个漂亮的证明需要大量的规划。Lean 接受上述证明项是因为它是一个完整的项，证明了一个与我们的目标定义上等价的陈述，关键在于要展开的定义是函数的复合。实际上，我们的目标函数 ``fun p ： X × X ↦ dist (f p.1) (f p.2)`` 并未以复合的形式给出。我们提供的证明项证明了 ``dist ∘ (fun p ： X × X ↦ (f p.1， f p.2))`` 的连续性，而这恰好与我们的目标函数定义上相等。但如果尝试从 ``apply continuous_dist.comp`` 开始逐步使用战术构建这个证明，Lean 的繁饰器将无法识别复合函数并拒绝应用此引理。当涉及类型乘积时，这种情况尤其糟糕。
+
+-- A better lemma to apply here is
+-- ``Continuous.dist {f g : X → Y} : Continuous f → Continuous g → Continuous (fun x ↦ dist (f x) (g x))``
+-- which is nicer to Lean's elaborator and also provides a shorter proof when directly providing a full
+-- proof term, as can be seen from the following two new proofs of the above statement:
+
+这里更适用的引理是
 ``Continuous.dist {f g : X → Y} : Continuous f → Continuous g → Continuous (fun x ↦ dist (f x) (g x))``
-which is nicer to Lean's elaborator and also provides a shorter proof when directly providing a full
-proof term, as can be seen from the following two new proofs of the above statement:
+它对 Lean 的繁饰器更友好，并且在直接提供完整证明项时也能提供更简短的证明，这一点从以下两个对上述陈述的新证明中可以看出：
 BOTH: -/
 -- QUOTE:
 example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Continuous f) :
@@ -125,15 +160,18 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
-Note that, without the elaboration issue coming from composition, another way to compress
-our proof would be to use ``Continuous.prod_map`` which is sometimes useful and gives
-as an alternate proof term ``continuous_dist.comp (hf.prod_map hf)`` which even shorter to type.
+-- Note that, without the elaboration issue coming from composition, another way to compress
+-- our proof would be to use ``Continuous.prod_map`` which is sometimes useful and gives
+-- as an alternate proof term ``continuous_dist.comp (hf.prod_map hf)`` which even shorter to type.
 
-Since it is sad to decide between a version which is better for elaboration and a version which is shorter
-to type, let us wrap this discussion with a last bit of compression offered
-by ``Continuous.fst'`` which allows to compress ``hf.comp continuous_fst`` to ``hf.fst'`` (and the same with ``snd``)
-and get our final proof, now bordering obfuscation.
+-- Since it is sad to decide between a version which is better for elaboration and a version which is shorter
+-- to type, let us wrap this discussion with a last bit of compression offered
+-- by ``Continuous.fst'`` which allows to compress ``hf.comp continuous_fst`` to ``hf.fst'`` (and the same with ``snd``)
+-- and get our final proof, now bordering obfuscation.
 
+请注意，如果不考虑来自组合的详细说明问题，压缩我们证明的另一种方法是使用``Continuous.prod_map``，它有时很有用，并给出一个替代的证明项``continuous_dist.comp (hf.prod_map hf)``，这个证明项甚至更短，输入起来也更方便。
+
+由于在便于详细阐述的版本和便于输入的较短版本之间做出选择令人感到遗憾，让我们以 ``Continuous.fst'`` 提供的最后一点压缩来结束这个讨论，它允许将 ``hf.comp continuous_fst`` 压缩为 ``hf.fst'``（``snd`` 也是如此），从而得到我们的最终证明，现在已接近晦涩难懂的程度。
 BOTH: -/
 -- QUOTE:
 example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Continuous f) :
@@ -142,9 +180,10 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
-It's your turn now to prove some continuity lemma. After trying the continuity tactic, you will need
-``Continuous.add``, ``continuous_pow`` and ``continuous_id`` to do it by hand.
+-- It's your turn now to prove some continuity lemma. After trying the continuity tactic, you will need
+-- ``Continuous.add``, ``continuous_pow`` and ``continuous_id`` to do it by hand.
 
+现在轮到你来证明一些连续性引理了。在尝试了连续性策略之后，你将需要使用 ``Continuous.add``、``continuous_pow`` 和 ``continuous_id`` 手动完成证明。
 BOTH: -/
 -- QUOTE:
 example {f : ℝ → X} (hf : Continuous f) : Continuous fun x : ℝ ↦ f (x ^ 2 + x) :=
@@ -156,7 +195,9 @@ example {f : ℝ → X} (hf : Continuous f) : Continuous fun x : ℝ ↦ f (x ^ 
   hf.comp <| (continuous_pow 2).add continuous_id
 
 /- TEXT:
-So far we saw continuity as a global notion, but one can also define continuity at a point.
+-- So far we saw continuity as a global notion, but one can also define continuity at a point.
+
+到目前为止，我们把连续性视为一个整体概念，但也可以定义某一点处的连续性。
 BOTH: -/
 -- QUOTE:
 example {X Y : Type*} [MetricSpace X] [MetricSpace Y] (f : X → Y) (a : X) :
@@ -166,10 +207,16 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] (f : X → Y) (a : X) :
 
 /- TEXT:
 
-Balls, open sets and closed sets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-- Balls, open sets and closed sets
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once we have a distance function, the most important geometric definitions are (open) balls and closed balls.
+-- Once we have a distance function, the most important geometric definitions are (open) balls and closed balls.
+
+
+球、开集与闭集
+^^^^^^^^^^^^^
+
+一旦我们有了距离函数，最重要的几何定义就是（开）球和闭球。
 
 BOTH: -/
 -- QUOTE:
@@ -183,7 +230,9 @@ example : Metric.closedBall a r = { b | dist b a ≤ r } :=
 -- QUOTE.
 
 /- TEXT:
-Note that `r` is any real number here, there is no sign restriction. Of course some statements do require a radius condition.
+-- Note that `r` is any real number here, there is no sign restriction. Of course some statements do require a radius condition.
+
+请注意，这里的 `r` 是任意实数，没有符号限制。当然，有些陈述确实需要半径条件。
 BOTH: -/
 -- QUOTE:
 example (hr : 0 < r) : a ∈ Metric.ball a r :=
@@ -194,8 +243,10 @@ example (hr : 0 ≤ r) : a ∈ Metric.closedBall a r :=
 -- QUOTE.
 
 /- TEXT:
-Once we have balls, we can define open sets. They are actually defined in a more general setting covered in the next section,
-but we have lemmas recasting the definition in terms of balls.
+-- Once we have balls, we can define open sets. They are actually defined in a more general setting covered in the next section,
+-- but we have lemmas recasting the definition in terms of balls.
+
+一旦我们有了球，就可以定义开集。实际上，它们是在下一节所涵盖的更一般的情形中定义的，但我们有一些引理将定义重新表述为用球来表示。
 
 BOTH: -/
 -- QUOTE:
@@ -204,7 +255,9 @@ example (s : Set X) : IsOpen s ↔ ∀ x ∈ s, ∃ ε > 0, Metric.ball x ε ⊆
 -- QUOTE.
 
 /- TEXT:
-Then closed sets are sets whose complement is open. Their important property is they are closed under limits. The closure of a set is the smallest closed set containing it.
+-- Then closed sets are sets whose complement is open. Their important property is they are closed under limits. The closure of a set is the smallest closed set containing it.
+
+那么闭集就是其补集为开集的集合。它们的重要性质是它们在极限运算下是封闭的。一个集合的闭包是包含它的最小闭集。
 BOTH: -/
 -- QUOTE:
 example {s : Set X} : IsClosed s ↔ IsOpen (sᶜ) :=
@@ -219,7 +272,9 @@ example {s : Set X} : a ∈ closure s ↔ ∀ ε > 0, ∃ b ∈ s, a ∈ Metric.
 -- QUOTE.
 
 /- TEXT:
-Do the next exercise without using `mem_closure_iff_seq_limit`
+-- Do the next exercise without using `mem_closure_iff_seq_limit`
+
+请在不使用 `mem_closure_iff_seq_limit` 的情况下完成下一个练习。
 BOTH: -/
 -- QUOTE:
 example {u : ℕ → X} (hu : Tendsto u atTop (𝓝 a)) {s : Set X} (hs : ∀ n, u n ∈ s) :
@@ -239,12 +294,13 @@ example {u : ℕ → X} (hu : Tendsto u atTop (𝓝 a)) {s : Set X} (hs : ∀ n,
 
 /- TEXT:
 
-Remember from the filters sections that neighborhood filters play a big role in Mathlib.
-In the metric space context, the crucial point is that balls provide bases for those filters.
-The main lemmas here are ``Metric.nhds_basis_ball`` and ``Metric.nhds_basis_closedBall``
-that claim this for open and closed balls with positive radius. The center point is an implicit
-argument so we can invoke ``Filter.HasBasis.mem_iff`` as in the following example.
+-- Remember from the filters sections that neighborhood filters play a big role in Mathlib.
+-- In the metric space context, the crucial point is that balls provide bases for those filters.
+-- The main lemmas here are ``Metric.nhds_basis_ball`` and ``Metric.nhds_basis_closedBall``
+-- that claim this for open and closed balls with positive radius. The center point is an implicit
+-- argument so we can invoke ``Filter.HasBasis.mem_iff`` as in the following example.
 
+请记住，在滤子部分中提到，邻域滤子在 Mathlib 中起着重要作用。在度量空间的背景下，关键在于球体为这些滤子提供了基。这里的主要引理是 ``Metric.nhds_basis_ball`` 和 ``Metric.nhds_basis_closedBall``，它们分别表明具有正半径的开球和闭球具有这一性质。中心点是一个隐式参数，因此我们可以像下面的例子那样调用 ``Filter.HasBasis.mem_iff``。
 BOTH: -/
 -- QUOTE:
 example {x : X} {s : Set X} : s ∈ 𝓝 x ↔ ∃ ε > 0, Metric.ball x ε ⊆ s :=
@@ -256,23 +312,33 @@ example {x : X} {s : Set X} : s ∈ 𝓝 x ↔ ∃ ε > 0, Metric.closedBall x �
 
 /- TEXT:
 
-Compactness
-^^^^^^^^^^^
+-- Compactness
+-- ^^^^^^^^^^^
 
-Compactness is an important topological notion. It distinguishes subsets of a metric space
-that enjoy the same kind of properties as segments in reals compared to other intervals:
+-- Compactness is an important topological notion. It distinguishes subsets of a metric space
+-- that enjoy the same kind of properties as segments in reals compared to other intervals:
 
-* Any sequence taking value in a compact set has a subsequence that converges in this set
-* Any continuous function on a nonempty compact set with values in real numbers is bounded and
-  achieves its bounds somewhere (this is called the extreme values theorem).
-* Compact sets are closed sets.
+-- * Any sequence taking value in a compact set has a subsequence that converges in this set
+-- * Any continuous function on a nonempty compact set with values in real numbers is bounded and
+--   achieves its bounds somewhere (this is called the extreme values theorem).
+-- * Compact sets are closed sets.
 
-Let us first check that the unit interval in reals is indeed a compact set, and then check the above
-claims for compact sets in general metric spaces. In the second statement we only
-need continuity on the given set so we will use ``ContinuousOn`` instead of ``Continuous``, and
-we will give separate statements for the minimum and the maximum. Of course all these results
-are deduced from more general versions, some of which will be discussed in later sections.
+-- Let us first check that the unit interval in reals is indeed a compact set, and then check the above
+-- claims for compact sets in general metric spaces. In the second statement we only
+-- need continuity on the given set so we will use ``ContinuousOn`` instead of ``Continuous``, and
+-- we will give separate statements for the minimum and the maximum. Of course all these results
+-- are deduced from more general versions, some of which will be discussed in later sections.
 
+紧致性
+^^^^^
+
+紧性是一个重要的拓扑概念。它区分了度量空间中的子集，这些子集具有与实数中的线段相同的性质，而与其他区间不同：
+
+* 任何取值于紧集中的序列都有一个子序列在该紧集中收敛。
+* 在非空紧集上取实数值的任何连续函数都是有界的，并且在某个地方达到其界值（这被称为极值定理）。
+* 紧集是闭集。
+
+首先让我们验证实数中的单位区间确实是一个紧集，然后验证一般度量空间中紧集的上述断言。在第二个陈述中，我们只需要在给定的集合上连续，因此我们将使用``ContinuousOn``而不是``Continuous``，并且我们将分别给出最小值和最大值的陈述。当然，所有这些结果都是从更一般的形式推导出来的，其中一些将在后面的章节中讨论。
 BOTH: -/
 -- QUOTE:
 example : IsCompact (Set.Icc 0 1 : Set ℝ) :=
@@ -298,7 +364,9 @@ example {s : Set X} (hs : IsCompact s) : IsClosed s :=
 
 /- TEXT:
 
-We can also specify that a metric spaces is globally compact, using an extra ``Prop``-valued type class:
+-- We can also specify that a metric spaces is globally compact, using an extra ``Prop``-valued type class:
+
+我们还可以通过添加一个额外的``Prop``值类型类来指定度量空间是全局紧致的：
 
 BOTH: -/
 -- QUOTE:
@@ -308,18 +376,26 @@ example {X : Type*} [MetricSpace X] [CompactSpace X] : IsCompact (univ : Set X) 
 
 /- TEXT:
 
-In a compact metric space any closed set is compact, this is ``IsClosed.isCompact``.
+-- In a compact metric space any closed set is compact, this is ``IsClosed.isCompact``.
 
+在紧致度量空间中，任何闭集都是紧致的，这就是``IsClosed.isCompact``。
 BOTH: -/
 #check IsCompact.isClosed
 
 /- TEXT:
-Uniformly continuous functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-- Uniformly continuous functions
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We now turn to uniformity notions on metric spaces : uniformly continuous functions, Cauchy sequences and completeness.
-Again those are defined in a more general context but we have lemmas in the metric name space to access their elementary definitions.
-We start with uniform continuity.
+-- We now turn to uniformity notions on metric spaces : uniformly continuous functions, Cauchy sequences and completeness.
+-- Again those are defined in a more general context but we have lemmas in the metric name space to access their elementary definitions.
+-- We start with uniform continuity.
+
+一致连续函数
+^^^^^^^^^^^
+
+现在我们来探讨度量空间上的均匀性概念：一致连续函数、柯西序列和完备性。
+同样，这些概念是在更一般的背景下定义的，但在度量空间中我们有引理来获取它们的基本定义。
+我们先从一致连续性讲起。
 
 BOTH: -/
 -- QUOTE:
@@ -330,22 +406,33 @@ example {X : Type*} [MetricSpace X] {Y : Type*} [MetricSpace Y] {f : X → Y} :
 -- QUOTE.
 
 /- TEXT:
-In order to practice manipulating all those definitions, we will prove that continuous
-functions from a compact metric space to a metric space are uniformly continuous
-(we will see a more general version in a later section).
+-- In order to practice manipulating all those definitions, we will prove that continuous
+-- functions from a compact metric space to a metric space are uniformly continuous
+-- (we will see a more general version in a later section).
 
-We will first give an informal sketch. Let ``f : X → Y`` be a continuous function from
-a compact metric space to a metric space.
-We fix ``ε > 0`` and start looking for some ``δ``.
+-- We will first give an informal sketch. Let ``f : X → Y`` be a continuous function from
+-- a compact metric space to a metric space.
+-- We fix ``ε > 0`` and start looking for some ``δ``.
 
-Let ``φ : X × X → ℝ := fun p ↦ dist (f p.1) (f p.2)`` and let ``K := { p : X × X | ε ≤ φ p }``.
-Observe ``φ`` is continuous since ``f`` and distance are continuous.
-And ``K`` is clearly closed (use ``isClosed_le``) hence compact since ``X`` is compact.
+-- Let ``φ : X × X → ℝ := fun p ↦ dist (f p.1) (f p.2)`` and let ``K := { p : X × X | ε ≤ φ p }``.
+-- Observe ``φ`` is continuous since ``f`` and distance are continuous.
+-- And ``K`` is clearly closed (use ``isClosed_le``) hence compact since ``X`` is compact.
 
-Then we discuss two possibilities using ``eq_empty_or_nonempty``.
-If ``K`` is empty then we are clearly done (we can set ``δ = 1`` for instance).
-So let's assume ``K`` is not empty, and use the extreme value theorem to choose ``(x₀, x₁)`` attaining the infimum
-of the distance function on ``K``. We can then set ``δ = dist x₀ x₁`` and check everything works.
+-- Then we discuss two possibilities using ``eq_empty_or_nonempty``.
+-- If ``K`` is empty then we are clearly done (we can set ``δ = 1`` for instance).
+-- So let's assume ``K`` is not empty, and use the extreme value theorem to choose ``(x₀, x₁)`` attaining the infimum
+-- of the distance function on ``K``. We can then set ``δ = dist x₀ x₁`` and check everything works.
+
+为了练习运用所有这些定义，我们将证明从紧致度量空间到度量空间的连续函数是一致连续的（在后面的章节中我们将看到更一般的形式）。
+
+我们首先给出一个非正式的概述。设``f : X → Y``是从一个紧致度量空间到一个度量空间的连续函数。
+我们固定``ε > 0``，然后开始寻找某个``δ``。
+
+令 ``φ : X × X → ℝ ：= fun p ↦ dist (f p.1) (f p.2)`` 以及 ``K := { p ： X × X | ε ≤ φ p }``。
+注意到由于 ``f`` 和距离函数都是连续的，所以 ``φ`` 也是连续的。
+并且 ``K`` 显然是闭集（使用 ``isClosed_le``），因此由于 ``X`` 是紧致的，所以 ``K`` 也是紧致的。
+
+然后我们使用``eq_empty_or_nonempty``来讨论两种可能性。如果集合 ``K`` 为空，那么显然我们已经完成了（例如，我们可以设 ``δ = 1``）。所以假设 ``K`` 不为空，利用极值定理选择 ``(x₀, x₁)`` 使得距离函数在 ``K`` 上达到最小值。然后我们可以设 ``δ = dist x₀ x₁`` 并检查一切是否都正常。
 
 BOTH: -/
 -- QUOTE:
@@ -384,13 +471,21 @@ example {X : Type*} [MetricSpace X] [CompactSpace X] {Y : Type*} [MetricSpace Y]
       exact H hxx'
 
 /- TEXT:
-Completeness
-^^^^^^^^^^^^
+-- Completeness
+-- ^^^^^^^^^^^^
 
-A Cauchy sequence in a metric space is a sequence whose terms get closer and closer to each other.
-There are a couple of equivalent ways to state that idea.
-In particular converging sequences are Cauchy. The converse is true only in so-called *complete*
-spaces.
+-- A Cauchy sequence in a metric space is a sequence whose terms get closer and closer to each other.
+-- There are a couple of equivalent ways to state that idea.
+-- In particular converging sequences are Cauchy. The converse is true only in so-called *complete*
+-- spaces.
+
+完整性
+^^^^^^
+
+
+度量空间中的柯西序列是指其各项越来越接近的序列。
+表述这一概念有几种等价的方式。
+特别是收敛序列是柯西序列。但反过来只有在所谓的**完备**空间中才成立。
 
 
 BOTH: -/
@@ -410,10 +505,12 @@ example [CompleteSpace X] (u : ℕ → X) (hu : CauchySeq u) :
 
 /- TEXT:
 
-We'll practice using this definition by proving a convenient criterion which is a special case of a
-criterion appearing in Mathlib. This is also a good opportunity to practice using big sums in
-a geometric context. In addition to the explanations from the filters section, you will probably need
-``tendsto_pow_atTop_nhds_zero_of_lt_one``, ``Tendsto.mul`` and ``dist_le_range_sum_dist``.
+-- We'll practice using this definition by proving a convenient criterion which is a special case of a
+-- criterion appearing in Mathlib. This is also a good opportunity to practice using big sums in
+-- a geometric context. In addition to the explanations from the filters section, you will probably need
+-- ``tendsto_pow_atTop_nhds_zero_of_lt_one``, ``Tendsto.mul`` and ``dist_le_range_sum_dist``.
+
+我们将通过证明一个方便的判别式来练习使用这个定义，该判别式是 Mathlib 中出现的一个判别式的特殊情况。这也是一个在几何背景下练习使用大和的好机会。除了滤子部分的解释外，您可能还需要使用 ``tendsto_pow_atTop_nhds_zero_of_lt_one``、``Tendsto.mul`` 和 ``dist_le_range_sum_dist``。
 BOTH: -/
 open BigOperators
 
@@ -468,10 +565,14 @@ example {u : ℕ → X} (hu : ∀ n : ℕ, dist (u n) (u (n + 1)) ≤ (1 / 2) ^ 
 
 /- TEXT:
 
-We are ready for the final boss of this section: Baire's theorem for complete metric spaces!
-The proof skeleton below shows interesting techniques. It uses the ``choose`` tactic in its exclamation
-mark variant (you should experiment with removing this exclamation mark) and it shows how to
-define something inductively in the middle of a proof using ``Nat.rec_on``.
+-- We are ready for the final boss of this section: Baire's theorem for complete metric spaces!
+-- The proof skeleton below shows interesting techniques. It uses the ``choose`` tactic in its exclamation
+-- mark variant (you should experiment with removing this exclamation mark) and it shows how to
+-- define something inductively in the middle of a proof using ``Nat.rec_on``.
+
+
+我们已准备好迎接本节的最终大 Boss：完备度量空间上的贝尔纲定理（Baire's theorem）！
+下面的证明框架展示了有趣的技术。它使用了感叹号形式的``choose``策略（您应该尝试去掉这个感叹号），并且展示了如何在证明过程中使用``Nat.rec_on``来递归定义某些内容。
 
 BOTH: -/
 -- QUOTE:
@@ -482,10 +583,12 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
   let B : ℕ → ℝ := fun n ↦ (1 / 2) ^ n
   have Bpos : ∀ n, 0 < B n
   sorry
-  /- Translate the density assumption into two functions `center` and `radius` associating
-    to any n, x, δ, δpos a center and a positive radius such that
-    `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
-    We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
+  -- /- Translate the density assumption into two functions `center` and `radius` associating
+  --   to any n, x, δ, δpos a center and a positive radius such that
+  --   `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
+  --   We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
+
+  /- 将密度假设转化为两个函数 `center` 和 `radius`，对于任意的 n、x、δ、δpos，这两个函数分别关联一个中心和一个正半径，使得 `closedBall center radius` 同时包含在 `f n` 和 `closedBall x δ` 中。我们还可以要求 `radius ≤ (1/2)^(n+1)`，以确保之后能得到一个柯西序列。-/
   have :
     ∀ (n : ℕ) (x : X),
       ∀ δ > 0, ∃ y : X, ∃ r > 0, r ≤ B (n + 1) ∧ closedBall y r ⊆ closedBall x δ ∩ f n :=
@@ -494,12 +597,14 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
   intro x
   rw [mem_closure_iff_nhds_basis nhds_basis_closedBall]
   intro ε εpos
-  /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x`
-    belonging to all `f n`. For this, we construct inductively a sequence
-    `F n = (c n, r n)` such that the closed ball `closedBall (c n) (r n)` is included
-    in the previous ball and in `f n`, and such that `r n` is small enough to ensure
-    that `c n` is a Cauchy sequence. Then `c n` converges to a limit which belongs
-    to all the `f n`. -/
+  -- /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x`
+  --   belonging to all `f n`. For this, we construct inductively a sequence
+  --   `F n = (c n, r n)` such that the closed ball `closedBall (c n) (r n)` is included
+  --   in the previous ball and in `f n`, and such that `r n` is small enough to ensure
+  --   that `c n` is a Cauchy sequence. Then `c n` converges to a limit which belongs
+  --   to all the `f n`. -/
+
+  /-  设 `ε` 为正数。我们需要在以 `x` 为圆心、半径为 `ε` 的球内找到一个点，该点属于所有的 `f n`。为此，我们递归地构造一个序列 `F n = (c n, r n)`，使得闭球 `closedBall (c n) (r n)` 包含在前一个球内且属于 `f n`，并且 `r n` 足够小以确保 `c n` 是一个柯西序列。那么 `c n` 收敛到一个极限，该极限属于所有的 `f n`。-/
   let F : ℕ → X × ℝ := fun n ↦
     Nat.recOn n (Prod.mk x (min ε (B 0)))
       fun n p ↦ Prod.mk (center n p.1 p.2) (radius n p.1 p.2)
@@ -511,10 +616,14 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
     sorry
   have cdist : ∀ n, dist (c n) (c (n + 1)) ≤ B n := by sorry
   have : CauchySeq c := cauchySeq_of_le_geometric_two' cdist
-  -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
-  rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
-  -- this point `y` will be the desired point. We will check that it belongs to all
-  -- `f n` and to `ball x ε`.
+  -- -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
+  -- rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
+  -- -- this point `y` will be the desired point. We will check that it belongs to all
+  -- -- `f n` and to `ball x ε`.
+
+  -- 由于序列 `c n` 在完备空间中是柯西序列，所以它收敛于极限 `y`。
+  -- 根据完备空间中柯西序列收敛的定理，存在 `y` 使得 `c n` 收敛于 `y`，记为 `ylim`。
+  -- 这个点 `y` 就是我们想要的点。接下来我们要验证它属于所有的 `f n` 以及 `ball x ε`。
   use y
   have I : ∀ n, ∀ m ≥ n, closedBall (c m) (r m) ⊆ closedBall (c n) (r n) := by sorry
   have yball : ∀ n, y ∈ closedBall (c n) (r n) := by sorry
@@ -526,10 +635,12 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
     Dense (⋂ n, f n) := by
   let B : ℕ → ℝ := fun n ↦ (1 / 2) ^ n
   have Bpos : ∀ n, 0 < B n := fun n ↦ pow_pos sorry n
-  /- Translate the density assumption into two functions `center` and `radius` associating
-    to any n, x, δ, δpos a center and a positive radius such that
-    `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
-    We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
+  -- /- Translate the density assumption into two functions `center` and `radius` associating
+  --   to any n, x, δ, δpos a center and a positive radius such that
+  --   `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
+  --   We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
+
+  /- 将密度假设转化为两个函数 `center` 和 `radius`，对于任意的 n、x、δ、δpos，这两个函数分别关联一个中心和一个正半径，使得 `closedBall center radius` 同时包含在 `f n` 和 `closedBall x δ` 中。我们还可以要求 `radius ≤ (1/2)^(n+1)`，以确保之后能得到一个柯西序列。 -/
   have :
     ∀ (n : ℕ) (x : X),
       ∀ δ > 0, ∃ y : X, ∃ r > 0, r ≤ B (n + 1) ∧ closedBall y r ⊆ closedBall x δ ∩ f n := by
@@ -561,11 +672,13 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
           )
   choose! center radius Hpos HB Hball using this
   refine fun x ↦ (mem_closure_iff_nhds_basis nhds_basis_closedBall).2 fun ε εpos ↦ ?_
-  /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x` belonging to all
-    `f n`. For this, we construct inductively a sequence `F n = (c n, r n)` such that the closed ball
-    `closedBall (c n) (r n)` is included in the previous ball and in `f n`, and such that
-    `r n` is small enough to ensure that `c n` is a Cauchy sequence. Then `c n` converges to a
-    limit which belongs to all the `f n`. -/
+  -- /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x` belonging to all
+  --   `f n`. For this, we construct inductively a sequence `F n = (c n, r n)` such that the closed ball
+  --   `closedBall (c n) (r n)` is included in the previous ball and in `f n`, and such that
+  --   `r n` is small enough to ensure that `c n` is a Cauchy sequence. Then `c n` converges to a
+  --   limit which belongs to all the `f n`. -/
+
+  /- `ε` 是正数。我们必须找到一个位于以 `x` 为中心、半径为 `ε` 的球内且属于所有 `f n` 的点。为此，我们递归地构造一个序列 `F n = (c n, r n)`，使得闭球 `closedBall (c n) (r n)` 包含在前一个球内且属于 `f n`，并且 `r n` 足够小以确保 `c n` 是一个柯西序列。然后 `c n` 收敛到一个属于所有 `f n` 的极限。 -/
   let F : ℕ → X × ℝ := fun n ↦
     Nat.recOn n (Prod.mk x (min ε (B 0))) fun n p ↦ Prod.mk (center n p.1 p.2) (radius n p.1 p.2)
   let c : ℕ → X := fun n ↦ (F n).1
@@ -595,10 +708,14 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
 
     exact I A
   have : CauchySeq c := cauchySeq_of_le_geometric_two' cdist
-  -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
-  rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
-  -- this point `y` will be the desired point. We will check that it belongs to all
-  -- `f n` and to `ball x ε`.
+  -- -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
+  -- rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
+  -- -- this point `y` will be the desired point. We will check that it belongs to all
+  -- -- `f n` and to `ball x ε`.
+
+  -- 由于序列 `c n` 在完备空间中是柯西序列，所以它收敛于某个极限 `y`。
+  -- 根据完备空间中柯西序列收敛的定理，存在 `y` 使得 `c n` 收敛于 `y`，记为 `ylim`。
+  -- 这个点 `y` 就是我们想要的点。接下来我们要验证它属于所有的 `f n` 以及 `ball x ε`。
   use y
   have I : ∀ n, ∀ m ≥ n, closedBall (c m) (r m) ⊆ closedBall (c n) (r n) := by
     intro n

--- a/MIL/C10_Topology/S02_Metric_Spaces.lean
+++ b/MIL/C10_Topology/S02_Metric_Spaces.lean
@@ -10,15 +10,6 @@ open Topology Filter
 
 .. _metric_spaces:
 
--- Metric spaces
--- --------------
-
--- Examples in the previous section focus on sequences of real numbers. In this section we will go up a bit in generality and focus on
--- metric spaces. A metric space is a type ``X`` equipped with a distance function ``dist : X → X → ℝ`` which is a generalization of
--- the function ``fun x y ↦ |x - y|`` from the case where ``X = ℝ``.
-
--- Introducing such a space is easy and we will check all properties required from the distance function.
-
 度量空间
 --------------
 
@@ -39,9 +30,6 @@ variable {X : Type*} [MetricSpace X] (a b c : X)
 -- QUOTE.
 
 /- TEXT:
--- Note we also have variants where the distance can be infinite or where ``dist a b`` can be zero without having ``a = b`` or both.
--- They are called ``EMetricSpace``, ``PseudoMetricSpace`` and ``PseudoEMetricSpace`` respectively (here "e" stands for "extended").
-
 
 请注意，我们还有其他变体，其中距离可以是无穷大，或者``dist a b``可以为零而不需要``a = b``或者两者皆是。
 它们分别被称为``EMetricSpace``、``PseudoMetricSpace``和``PseudoEMetricSpace``（这里“e”代表“扩展”）。
@@ -55,15 +43,6 @@ BOTH: -/
 #check PseudoEMetricSpace
 
 /- TEXT:
--- Note that our journey from ``ℝ`` to metric spaces jumped over the special case of normed spaces that also require linear algebra and
--- will be explained as part of the calculus chapter.
-
--- Convergence and continuity
--- ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
--- Using distance functions, we can already define convergent sequences and continuous functions between metric spaces.
--- They are actually defined in a more general setting covered in the next section,
--- but we have lemmas recasting the definition in terms of distances.
 
 请注意，我们从实数集``ℝ``到度量空间的旅程跳过了需要线性代数知识的赋范空间这一特殊情况，这部分内容将在微积分章节中进行解释。
 
@@ -88,14 +67,6 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} :
 /- TEXT:
 .. index:: continuity, tactics ; continuity
 
-
--- A *lot* of lemmas have some continuity assumptions, so we end up proving a lot of continuity results and there
--- is a ``continuity`` tactic devoted to this task. Let's prove a continuity statement that will be needed
--- in an exercise below. Notice that Lean knows how to treat a product of two metric spaces as a metric space, so
--- it makes sense to consider continuous functions from ``X × X`` to ``ℝ``.
--- In particular the (uncurried version of the) distance function is such a function.
-
-
 **很多**引理都有一些连续性假设，所以我们最终要证明很多连续性结果，并且有一个专门用于此任务的``连续性``策略。让我们证明一个连续性陈述，它将在下面的一个练习中用到。请注意，Lean 知道如何将两个度量空间的乘积视为一个度量空间，因此考虑从 ``X × X`` 到 ``ℝ`` 的连续函数是有意义的。
 特别是距离函数（未卷曲的版本）就是这样一种函数。
 BOTH: -/
@@ -105,17 +76,6 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
--- This tactic is a bit slow, so it is also useful to know
--- how to do it by hand. We first need to use that ``fun p : X × X ↦ f p.1`` is continuous because it
--- is the composition of ``f``, which is continuous by assumption ``hf``, and the projection ``prod.fst`` whose continuity
--- is the content of the lemma ``continuous_fst``. The composition property is ``Continuous.comp`` which is
--- in the ``Continuous`` namespace so we can use dot notation to compress
--- ``Continuous.comp hf continuous_fst`` into ``hf.comp continuous_fst`` which is actually more readable
--- since it really reads as composing our assumption and our lemma.
--- We can do the same for the second component to get continuity of ``fun p : X × X ↦ f p.2``. We then assemble
--- those two continuities using ``Continuous.prod_mk`` to get
--- ``(hf.comp continuous_fst).prod_mk (hf.comp continuous_snd) : Continuous (fun p : X × X ↦ (f p.1, f p.2))``
--- and compose once more to get our full proof.
 
 这种策略有点慢，所以了解如何手动操作也是有用的。我们首先需要利用``fun p : X × X ↦ f p.1``是连续的这一事实，因为它是连续函数 ``f``（由假设 ``hf`` 给出）与投影 ``prod.fst`` 的复合，而 ``prod.fst`` 的连续性正是引理 ``continuous_fst`` 的内容。复合性质是 ``Continuous.comp``，它在 ``Continuous`` 命名空间中，所以我们可以用点表示法将``Continuous.comp hf continuous_fst``压缩为``hf.comp continuous_fst``，这实际上更易读，因为它确实读作将我们的假设和引理进行复合。我们对第二个分量做同样的操作，以获得``fun p ： X × X ↦ f p.2``的连续性。然后，我们使用 ``Continuous.prod_mk`` 将这两个连续性组合起来，得到``(hf.comp continuous_fst).prod_mk (hf.comp continuous_snd) : Continuous (fun p : X × X ↦ (f p.1， f p.2))``，并再次复合以完成我们的完整证明。
 BOTH: -/
@@ -126,22 +86,8 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
--- The combination of ``Continuous.prod_mk`` and ``continuous_dist`` via ``Continuous.comp`` feels clunky,
--- even when heavily using dot notation as above. A more serious issue is that this nice proof requires a lot of
--- planning. Lean accepts the above proof term because it is a full term proving a statement which is
--- definitionally equivalent to our goal, the crucial definition to unfold being that of a composition of functions.
--- Indeed our target function ``fun p : X × X ↦ dist (f p.1) (f p.2)`` is not presented as a composition.
--- The proof term we provided proves continuity of ``dist ∘ (fun p : X × X ↦ (f p.1, f p.2))`` which happens
--- to be definitionally equal to our target function. But if we try to build this proof gradually using
--- tactics starting with ``apply continuous_dist.comp`` then Lean's elaborator will fail to recognize a
--- composition and refuse to apply this lemma. It is especially bad at this when products of types are involved.
 
 通过 ``Continuous.comp`` 将 ``Continuous.prod_mk`` 和 ``continuous_dist`` 结合起来的方式感觉很笨拙，即便像上面那样大量使用点标记也是如此。更严重的问题在于，这个漂亮的证明需要大量的规划。Lean 接受上述证明项是因为它是一个完整的项，证明了一个与我们的目标定义上等价的陈述，关键在于要展开的定义是函数的复合。实际上，我们的目标函数 ``fun p ： X × X ↦ dist (f p.1) (f p.2)`` 并未以复合的形式给出。我们提供的证明项证明了 ``dist ∘ (fun p ： X × X ↦ (f p.1， f p.2))`` 的连续性，而这恰好与我们的目标函数定义上相等。但如果尝试从 ``apply continuous_dist.comp`` 开始逐步使用战术构建这个证明，Lean 的繁饰器将无法识别复合函数并拒绝应用此引理。当涉及类型乘积时，这种情况尤其糟糕。
-
--- A better lemma to apply here is
--- ``Continuous.dist {f g : X → Y} : Continuous f → Continuous g → Continuous (fun x ↦ dist (f x) (g x))``
--- which is nicer to Lean's elaborator and also provides a shorter proof when directly providing a full
--- proof term, as can be seen from the following two new proofs of the above statement:
 
 这里更适用的引理是
 ``Continuous.dist {f g : X → Y} : Continuous f → Continuous g → Continuous (fun x ↦ dist (f x) (g x))``
@@ -160,15 +106,6 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
--- Note that, without the elaboration issue coming from composition, another way to compress
--- our proof would be to use ``Continuous.prod_map`` which is sometimes useful and gives
--- as an alternate proof term ``continuous_dist.comp (hf.prod_map hf)`` which even shorter to type.
-
--- Since it is sad to decide between a version which is better for elaboration and a version which is shorter
--- to type, let us wrap this discussion with a last bit of compression offered
--- by ``Continuous.fst'`` which allows to compress ``hf.comp continuous_fst`` to ``hf.fst'`` (and the same with ``snd``)
--- and get our final proof, now bordering obfuscation.
-
 请注意，如果不考虑来自组合的详细说明问题，压缩我们证明的另一种方法是使用``Continuous.prod_map``，它有时很有用，并给出一个替代的证明项``continuous_dist.comp (hf.prod_map hf)``，这个证明项甚至更短，输入起来也更方便。
 
 由于在便于详细阐述的版本和便于输入的较短版本之间做出选择令人感到遗憾，让我们以 ``Continuous.fst'`` 提供的最后一点压缩来结束这个讨论，它允许将 ``hf.comp continuous_fst`` 压缩为 ``hf.fst'``（``snd`` 也是如此），从而得到我们的最终证明，现在已接近晦涩难懂的程度。
@@ -180,8 +117,6 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] {f : X → Y} (hf : Contin
 -- QUOTE.
 
 /- TEXT:
--- It's your turn now to prove some continuity lemma. After trying the continuity tactic, you will need
--- ``Continuous.add``, ``continuous_pow`` and ``continuous_id`` to do it by hand.
 
 现在轮到你来证明一些连续性引理了。在尝试了连续性策略之后，你将需要使用 ``Continuous.add``、``continuous_pow`` 和 ``continuous_id`` 手动完成证明。
 BOTH: -/
@@ -195,7 +130,6 @@ example {f : ℝ → X} (hf : Continuous f) : Continuous fun x : ℝ ↦ f (x ^ 
   hf.comp <| (continuous_pow 2).add continuous_id
 
 /- TEXT:
--- So far we saw continuity as a global notion, but one can also define continuity at a point.
 
 到目前为止，我们把连续性视为一个整体概念，但也可以定义某一点处的连续性。
 BOTH: -/
@@ -206,12 +140,6 @@ example {X Y : Type*} [MetricSpace X] [MetricSpace Y] (f : X → Y) (a : X) :
 -- QUOTE.
 
 /- TEXT:
-
--- Balls, open sets and closed sets
--- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
--- Once we have a distance function, the most important geometric definitions are (open) balls and closed balls.
-
 
 球、开集与闭集
 ^^^^^^^^^^^^^
@@ -230,7 +158,6 @@ example : Metric.closedBall a r = { b | dist b a ≤ r } :=
 -- QUOTE.
 
 /- TEXT:
--- Note that `r` is any real number here, there is no sign restriction. Of course some statements do require a radius condition.
 
 请注意，这里的 `r` 是任意实数，没有符号限制。当然，有些陈述确实需要半径条件。
 BOTH: -/
@@ -243,8 +170,6 @@ example (hr : 0 ≤ r) : a ∈ Metric.closedBall a r :=
 -- QUOTE.
 
 /- TEXT:
--- Once we have balls, we can define open sets. They are actually defined in a more general setting covered in the next section,
--- but we have lemmas recasting the definition in terms of balls.
 
 一旦我们有了球，就可以定义开集。实际上，它们是在下一节所涵盖的更一般的情形中定义的，但我们有一些引理将定义重新表述为用球来表示。
 
@@ -255,7 +180,6 @@ example (s : Set X) : IsOpen s ↔ ∀ x ∈ s, ∃ ε > 0, Metric.ball x ε ⊆
 -- QUOTE.
 
 /- TEXT:
--- Then closed sets are sets whose complement is open. Their important property is they are closed under limits. The closure of a set is the smallest closed set containing it.
 
 那么闭集就是其补集为开集的集合。它们的重要性质是它们在极限运算下是封闭的。一个集合的闭包是包含它的最小闭集。
 BOTH: -/
@@ -272,8 +196,6 @@ example {s : Set X} : a ∈ closure s ↔ ∀ ε > 0, ∃ b ∈ s, a ∈ Metric.
 -- QUOTE.
 
 /- TEXT:
--- Do the next exercise without using `mem_closure_iff_seq_limit`
-
 请在不使用 `mem_closure_iff_seq_limit` 的情况下完成下一个练习。
 BOTH: -/
 -- QUOTE:
@@ -294,12 +216,6 @@ example {u : ℕ → X} (hu : Tendsto u atTop (𝓝 a)) {s : Set X} (hs : ∀ n,
 
 /- TEXT:
 
--- Remember from the filters sections that neighborhood filters play a big role in Mathlib.
--- In the metric space context, the crucial point is that balls provide bases for those filters.
--- The main lemmas here are ``Metric.nhds_basis_ball`` and ``Metric.nhds_basis_closedBall``
--- that claim this for open and closed balls with positive radius. The center point is an implicit
--- argument so we can invoke ``Filter.HasBasis.mem_iff`` as in the following example.
-
 请记住，在滤子部分中提到，邻域滤子在 Mathlib 中起着重要作用。在度量空间的背景下，关键在于球体为这些滤子提供了基。这里的主要引理是 ``Metric.nhds_basis_ball`` 和 ``Metric.nhds_basis_closedBall``，它们分别表明具有正半径的开球和闭球具有这一性质。中心点是一个隐式参数，因此我们可以像下面的例子那样调用 ``Filter.HasBasis.mem_iff``。
 BOTH: -/
 -- QUOTE:
@@ -311,23 +227,6 @@ example {x : X} {s : Set X} : s ∈ 𝓝 x ↔ ∃ ε > 0, Metric.closedBall x �
 -- QUOTE.
 
 /- TEXT:
-
--- Compactness
--- ^^^^^^^^^^^
-
--- Compactness is an important topological notion. It distinguishes subsets of a metric space
--- that enjoy the same kind of properties as segments in reals compared to other intervals:
-
--- * Any sequence taking value in a compact set has a subsequence that converges in this set
--- * Any continuous function on a nonempty compact set with values in real numbers is bounded and
---   achieves its bounds somewhere (this is called the extreme values theorem).
--- * Compact sets are closed sets.
-
--- Let us first check that the unit interval in reals is indeed a compact set, and then check the above
--- claims for compact sets in general metric spaces. In the second statement we only
--- need continuity on the given set so we will use ``ContinuousOn`` instead of ``Continuous``, and
--- we will give separate statements for the minimum and the maximum. Of course all these results
--- are deduced from more general versions, some of which will be discussed in later sections.
 
 紧致性
 ^^^^^
@@ -364,8 +263,6 @@ example {s : Set X} (hs : IsCompact s) : IsClosed s :=
 
 /- TEXT:
 
--- We can also specify that a metric spaces is globally compact, using an extra ``Prop``-valued type class:
-
 我们还可以通过添加一个额外的``Prop``值类型类来指定度量空间是全局紧致的：
 
 BOTH: -/
@@ -376,20 +273,11 @@ example {X : Type*} [MetricSpace X] [CompactSpace X] : IsCompact (univ : Set X) 
 
 /- TEXT:
 
--- In a compact metric space any closed set is compact, this is ``IsClosed.isCompact``.
-
 在紧致度量空间中，任何闭集都是紧致的，这就是``IsClosed.isCompact``。
 BOTH: -/
 #check IsCompact.isClosed
 
 /- TEXT:
--- Uniformly continuous functions
--- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
--- We now turn to uniformity notions on metric spaces : uniformly continuous functions, Cauchy sequences and completeness.
--- Again those are defined in a more general context but we have lemmas in the metric name space to access their elementary definitions.
--- We start with uniform continuity.
-
 一致连续函数
 ^^^^^^^^^^^
 
@@ -406,22 +294,6 @@ example {X : Type*} [MetricSpace X] {Y : Type*} [MetricSpace Y] {f : X → Y} :
 -- QUOTE.
 
 /- TEXT:
--- In order to practice manipulating all those definitions, we will prove that continuous
--- functions from a compact metric space to a metric space are uniformly continuous
--- (we will see a more general version in a later section).
-
--- We will first give an informal sketch. Let ``f : X → Y`` be a continuous function from
--- a compact metric space to a metric space.
--- We fix ``ε > 0`` and start looking for some ``δ``.
-
--- Let ``φ : X × X → ℝ := fun p ↦ dist (f p.1) (f p.2)`` and let ``K := { p : X × X | ε ≤ φ p }``.
--- Observe ``φ`` is continuous since ``f`` and distance are continuous.
--- And ``K`` is clearly closed (use ``isClosed_le``) hence compact since ``X`` is compact.
-
--- Then we discuss two possibilities using ``eq_empty_or_nonempty``.
--- If ``K`` is empty then we are clearly done (we can set ``δ = 1`` for instance).
--- So let's assume ``K`` is not empty, and use the extreme value theorem to choose ``(x₀, x₁)`` attaining the infimum
--- of the distance function on ``K``. We can then set ``δ = dist x₀ x₁`` and check everything works.
 
 为了练习运用所有这些定义，我们将证明从紧致度量空间到度量空间的连续函数是一致连续的（在后面的章节中我们将看到更一般的形式）。
 
@@ -471,15 +343,8 @@ example {X : Type*} [MetricSpace X] [CompactSpace X] {Y : Type*} [MetricSpace Y]
       exact H hxx'
 
 /- TEXT:
--- Completeness
--- ^^^^^^^^^^^^
 
--- A Cauchy sequence in a metric space is a sequence whose terms get closer and closer to each other.
--- There are a couple of equivalent ways to state that idea.
--- In particular converging sequences are Cauchy. The converse is true only in so-called *complete*
--- spaces.
-
-完整性
+完备性
 ^^^^^^
 
 
@@ -505,12 +370,7 @@ example [CompleteSpace X] (u : ℕ → X) (hu : CauchySeq u) :
 
 /- TEXT:
 
--- We'll practice using this definition by proving a convenient criterion which is a special case of a
--- criterion appearing in Mathlib. This is also a good opportunity to practice using big sums in
--- a geometric context. In addition to the explanations from the filters section, you will probably need
--- ``tendsto_pow_atTop_nhds_zero_of_lt_one``, ``Tendsto.mul`` and ``dist_le_range_sum_dist``.
-
-我们将通过证明一个方便的判别式来练习使用这个定义，该判别式是 Mathlib 中出现的一个判别式的特殊情况。这也是一个在几何背景下练习使用大和的好机会。除了滤子部分的解释外，您可能还需要使用 ``tendsto_pow_atTop_nhds_zero_of_lt_one``、``Tendsto.mul`` 和 ``dist_le_range_sum_dist``。
+我们将通过证明一个方便的判别式来练习使用这个定义，该判别式是 Mathlib 中出现的一个判别式的特殊情况。这也是一个在几何背景下练习使用大求和符号的好机会。除了滤子部分的解释外，您可能还需要使用 ``tendsto_pow_atTop_nhds_zero_of_lt_one``、``Tendsto.mul`` 和 ``dist_le_range_sum_dist``。
 BOTH: -/
 open BigOperators
 
@@ -565,12 +425,6 @@ example {u : ℕ → X} (hu : ∀ n : ℕ, dist (u n) (u (n + 1)) ≤ (1 / 2) ^ 
 
 /- TEXT:
 
--- We are ready for the final boss of this section: Baire's theorem for complete metric spaces!
--- The proof skeleton below shows interesting techniques. It uses the ``choose`` tactic in its exclamation
--- mark variant (you should experiment with removing this exclamation mark) and it shows how to
--- define something inductively in the middle of a proof using ``Nat.rec_on``.
-
-
 我们已准备好迎接本节的最终大 Boss：完备度量空间上的贝尔纲定理（Baire's theorem）！
 下面的证明框架展示了有趣的技术。它使用了感叹号形式的``choose``策略（您应该尝试去掉这个感叹号），并且展示了如何在证明过程中使用``Nat.rec_on``来递归定义某些内容。
 
@@ -583,11 +437,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
   let B : ℕ → ℝ := fun n ↦ (1 / 2) ^ n
   have Bpos : ∀ n, 0 < B n
   sorry
-  -- /- Translate the density assumption into two functions `center` and `radius` associating
-  --   to any n, x, δ, δpos a center and a positive radius such that
-  --   `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
-  --   We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
-
   /- 将密度假设转化为两个函数 `center` 和 `radius`，对于任意的 n、x、δ、δpos，这两个函数分别关联一个中心和一个正半径，使得 `closedBall center radius` 同时包含在 `f n` 和 `closedBall x δ` 中。我们还可以要求 `radius ≤ (1/2)^(n+1)`，以确保之后能得到一个柯西序列。-/
   have :
     ∀ (n : ℕ) (x : X),
@@ -597,13 +446,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
   intro x
   rw [mem_closure_iff_nhds_basis nhds_basis_closedBall]
   intro ε εpos
-  -- /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x`
-  --   belonging to all `f n`. For this, we construct inductively a sequence
-  --   `F n = (c n, r n)` such that the closed ball `closedBall (c n) (r n)` is included
-  --   in the previous ball and in `f n`, and such that `r n` is small enough to ensure
-  --   that `c n` is a Cauchy sequence. Then `c n` converges to a limit which belongs
-  --   to all the `f n`. -/
-
   /-  设 `ε` 为正数。我们需要在以 `x` 为圆心、半径为 `ε` 的球内找到一个点，该点属于所有的 `f n`。为此，我们递归地构造一个序列 `F n = (c n, r n)`，使得闭球 `closedBall (c n) (r n)` 包含在前一个球内且属于 `f n`，并且 `r n` 足够小以确保 `c n` 是一个柯西序列。那么 `c n` 收敛到一个极限，该极限属于所有的 `f n`。-/
   let F : ℕ → X × ℝ := fun n ↦
     Nat.recOn n (Prod.mk x (min ε (B 0)))
@@ -616,11 +458,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
     sorry
   have cdist : ∀ n, dist (c n) (c (n + 1)) ≤ B n := by sorry
   have : CauchySeq c := cauchySeq_of_le_geometric_two' cdist
-  -- -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
-  -- rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
-  -- -- this point `y` will be the desired point. We will check that it belongs to all
-  -- -- `f n` and to `ball x ε`.
-
   -- 由于序列 `c n` 在完备空间中是柯西序列，所以它收敛于极限 `y`。
   -- 根据完备空间中柯西序列收敛的定理，存在 `y` 使得 `c n` 收敛于 `y`，记为 `ylim`。
   -- 这个点 `y` 就是我们想要的点。接下来我们要验证它属于所有的 `f n` 以及 `ball x ε`。
@@ -635,11 +472,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
     Dense (⋂ n, f n) := by
   let B : ℕ → ℝ := fun n ↦ (1 / 2) ^ n
   have Bpos : ∀ n, 0 < B n := fun n ↦ pow_pos sorry n
-  -- /- Translate the density assumption into two functions `center` and `radius` associating
-  --   to any n, x, δ, δpos a center and a positive radius such that
-  --   `closedBall center radius` is included both in `f n` and in `closedBall x δ`.
-  --   We can also require `radius ≤ (1/2)^(n+1)`, to ensure we get a Cauchy sequence later. -/
-
   /- 将密度假设转化为两个函数 `center` 和 `radius`，对于任意的 n、x、δ、δpos，这两个函数分别关联一个中心和一个正半径，使得 `closedBall center radius` 同时包含在 `f n` 和 `closedBall x δ` 中。我们还可以要求 `radius ≤ (1/2)^(n+1)`，以确保之后能得到一个柯西序列。 -/
   have :
     ∀ (n : ℕ) (x : X),
@@ -672,12 +504,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
           )
   choose! center radius Hpos HB Hball using this
   refine fun x ↦ (mem_closure_iff_nhds_basis nhds_basis_closedBall).2 fun ε εpos ↦ ?_
-  -- /- `ε` is positive. We have to find a point in the ball of radius `ε` around `x` belonging to all
-  --   `f n`. For this, we construct inductively a sequence `F n = (c n, r n)` such that the closed ball
-  --   `closedBall (c n) (r n)` is included in the previous ball and in `f n`, and such that
-  --   `r n` is small enough to ensure that `c n` is a Cauchy sequence. Then `c n` converges to a
-  --   limit which belongs to all the `f n`. -/
-
   /- `ε` 是正数。我们必须找到一个位于以 `x` 为中心、半径为 `ε` 的球内且属于所有 `f n` 的点。为此，我们递归地构造一个序列 `F n = (c n, r n)`，使得闭球 `closedBall (c n) (r n)` 包含在前一个球内且属于 `f n`，并且 `r n` 足够小以确保 `c n` 是一个柯西序列。然后 `c n` 收敛到一个属于所有 `f n` 的极限。 -/
   let F : ℕ → X × ℝ := fun n ↦
     Nat.recOn n (Prod.mk x (min ε (B 0))) fun n p ↦ Prod.mk (center n p.1 p.2) (radius n p.1 p.2)
@@ -708,11 +534,6 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
 
     exact I A
   have : CauchySeq c := cauchySeq_of_le_geometric_two' cdist
-  -- -- as the sequence `c n` is Cauchy in a complete space, it converges to a limit `y`.
-  -- rcases cauchySeq_tendsto_of_complete this with ⟨y, ylim⟩
-  -- -- this point `y` will be the desired point. We will check that it belongs to all
-  -- -- `f n` and to `ball x ε`.
-
   -- 由于序列 `c n` 在完备空间中是柯西序列，所以它收敛于某个极限 `y`。
   -- 根据完备空间中柯西序列收敛的定理，存在 `y` 使得 `c n` 收敛于 `y`，记为 `ylim`。
   -- 这个点 `y` 就是我们想要的点。接下来我们要验证它属于所有的 `f n` 以及 `ball x ε`。
@@ -736,8 +557,3 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
   calc
     dist y x ≤ r 0 := yball 0
     _ ≤ ε := min_le_left _ _
-
-
-/- TEXT:
-
-BOTH: -/

--- a/MIL/C10_Topology/S03_Topological_Spaces.lean
+++ b/MIL/C10_Topology/S03_Topological_Spaces.lean
@@ -9,21 +9,17 @@ open Set Filter Topology
 
 .. _topological_spaces:
 
-Topological spaces
-------------------
+拓扑空间
+--------
 
-Fundamentals
+
+基础
 ^^^^^^^^^^^^
 
-We now go up in generality and introduce topological spaces. We will review the two main ways to define
-topological spaces and then explain how the category of topological spaces is much better behaved than
-the category of metric spaces. Note that we won't be using Mathlib category theory here, only having
-a somewhat categorical point of view.
 
-The first way to think about the transition from metric spaces to topological spaces is that we only
-remember the notion of open sets (or equivalently the notion of closed sets). From this point of view,
-a topological space is a type equipped with a collection of sets that are called open sets. This collection
-has to satisfy a number of axioms presented below (this collection is slightly redundant but we will ignore that).
+我们现在提高一般性，引入拓扑空间。我们将回顾定义拓扑空间的两种主要方式，然后解释拓扑空间范畴比度量空间范畴表现得要好得多。请注意，这里我们不会使用 Mathlib 的范畴论，只是采用一种稍微范畴化一点的观点。
+
+从度量空间到拓扑空间转变的第一种思考方式是，我们只记住开集（或等价地，闭集）的概念。从这个角度来看，拓扑空间是一种配备了被称为开集的集合族的类型。这个集合族必须满足下面给出的若干公理（这个集合族稍有冗余，但我们忽略这一点）。
 BOTH: -/
 -- QUOTE:
 section
@@ -45,8 +41,7 @@ example {ι : Type*} [Fintype ι] {s : ι → Set X} (hs : ∀ i, IsOpen (s i)) 
 
 /- TEXT:
 
-Closed sets are then defined as sets whose complement  is open. A function between topological spaces
-is (globally) continuous if all preimages of open sets are open.
+闭集被定义为补集是开集的集合。拓扑空间之间的函数是（全局）连续的，当且仅当所有开集的原像都是开集。
 BOTH: -/
 -- QUOTE:
 variable {Y : Type*} [TopologicalSpace Y]
@@ -56,23 +51,9 @@ example {f : X → Y} : Continuous f ↔ ∀ s, IsOpen s → IsOpen (f ⁻¹' s)
 -- QUOTE.
 
 /- TEXT:
-With this definition we already see that, compared to metric spaces, topological spaces only remember
-enough information to talk about continuous functions: two topological structures on a type are
-the same if and only if they have the same continuous functions (indeed the identity function will
-be continuous in both direction if and only if the two structures have the same open sets).
+根据这个定义，我们已经可以看出，与度量空间相比，拓扑空间仅保留了足够的信息来讨论连续函数：如果且仅如果两种拓扑结构具有相同的连续函数，则类型上的两种拓扑结构相同（实际上，当且仅当两种结构具有相同的开集时，恒等函数在两个方向上都是连续的）。
 
-However as soon as we move on to continuity at a point we see the limitations of the approach based
-on open sets. In Mathlib we frequently think of topological spaces as types equipped
-with a neighborhood filter ``𝓝 x`` attached to each point ``x`` (the corresponding function
-``X → Filter X`` satisfies certain conditions explained further down). Remember from the filters section that
-these gadgets play two related roles. First ``𝓝 x`` is seen as the generalized set of points of ``X``
-that are close to ``x``. And then it is seen as giving a way to say, for any predicate ``P : X → Prop``,
-that this predicate holds for points that are close enough to ``x``. Let us state
-that ``f : X → Y`` is continuous at ``x``. The purely filtery way is to say that the direct image under
-``f`` of the generalized set of points that are close to ``x`` is contained in the generalized set of
-points that are close to ``f x``. Recall this is spelled either ``map f (𝓝 x) ≤ 𝓝 (f x)``
-or ``Tendsto f (𝓝 x) (𝓝 (f x))``.
-
+然而，一旦我们转向某一点的连续性，就会看到基于开集的方法的局限性。在 Mathlib 中，我们经常将拓扑空间视为每个点 x 都附带一个邻域滤子``𝓝 x``的类型（相应的函数``X → Filter X``满足进一步说明的某些条件）。回想一下滤子部分的内容，这些工具发挥着两个相关的作用。首先，``𝓝 x``被视为 X 中接近 ``x`` 的点的广义集合。其次，它被视为一种方式，用于说明对于任何谓词``P : X → Prop``，该谓词对于足够接近 x 的点成立。让我们来陈述 ``f ： X → Y`` 在 ``x`` 处连续。纯粹基于滤子的说法是，``f`` 下 ``x`` 附近点的广义集合的直接像包含在 ``f x`` 附近点的广义集合中。回想一下，这可以写成``map f (𝓝 x) ≤ 𝓝 (f x)``或者``Tendsto f (𝓝 x) (𝓝 (f x))``。
 BOTH: -/
 -- QUOTE:
 example {f : X → Y} {x : X} : ContinuousAt f x ↔ map f (𝓝 x) ≤ 𝓝 (f x) :=
@@ -80,11 +61,7 @@ example {f : X → Y} {x : X} : ContinuousAt f x ↔ map f (𝓝 x) ≤ 𝓝 (f 
 -- QUOTE.
 
 /- TEXT:
-One can also spell it using both neighborhoods seen as ordinary sets and a neighborhood filter
-seen as a generalized set: "for any neighborhood ``U`` of ``f x``, all points close to ``x``
-are sent to ``U``". Note that the proof is again ``iff.rfl``, this point of view is definitionally
-equivalent to the previous one.
-
+还可以使用被视为普通集合的邻域和被视为广义集合的邻域滤子来拼写它：“对于 ``f x`` 的任何邻域 ``U`` ，所有靠近 ``x`` 的点都被发送到 ``U`` ”。请注意，证明又是 ``iff.rfl`` ，这种观点在定义上与前一种观点等价。
 BOTH: -/
 -- QUOTE:
 example {f : X → Y} {x : X} : ContinuousAt f x ↔ ∀ U ∈ 𝓝 (f x), ∀ᶠ x in 𝓝 x, f x ∈ U :=
@@ -92,10 +69,7 @@ example {f : X → Y} {x : X} : ContinuousAt f x ↔ ∀ U ∈ 𝓝 (f x), ∀�
 -- QUOTE.
 
 /- TEXT:
-We now explain how to go from one point of view to the other. In terms of open sets, we can
-simply define members of ``𝓝 x`` as sets that contain an open set containing ``x``.
-
-
+现在我们来解释如何从一种观点转换到另一种观点。就开集而言，我们可以简单地将 ``𝓝 x`` 的成员定义为包含一个包含 ``x`` 的开集的集合。
 BOTH: -/
 -- QUOTE:
 example {x : X} {s : Set X} : s ∈ 𝓝 x ↔ ∃ t, t ⊆ s ∧ IsOpen t ∧ x ∈ t :=
@@ -103,13 +77,9 @@ example {x : X} {s : Set X} : s ∈ 𝓝 x ↔ ∃ t, t ⊆ s ∧ IsOpen t ∧ x
 -- QUOTE.
 
 /- TEXT:
-To go in the other direction we need to discuss the condition that ``𝓝 : X → Filter X`` must satisfy
-in order to be the neighborhood function of a topology.
+要朝另一方向进行，我们需要讨论``𝓝 ： X → Filter X``成为拓扑的邻域函数必须满足的条件。
 
-The first constraint is that ``𝓝 x``, seen as a generalized set, contains the set ``{x}`` seen as the generalized set
-``pure x`` (explaining this weird name would be too much of a digression, so we simply accept it for now).
-Another way to say it is that if a predicate holds for points close to ``x`` then it holds at ``x``.
-
+第一个约束条件是，将``𝓝 x``视为广义集合时，它将包含被视为广义集合``pure x``的集合``{x}``（解释这个奇怪的名字会离题太远，所以我们暂时接受它）。另一种说法是，如果一个谓词对靠近``x``的点成立，那么它在``x``处也成立。
 BOTH: -/
 -- QUOTE:
 example (x : X) : pure x ≤ 𝓝 x :=
@@ -120,8 +90,7 @@ example (x : X) (P : X → Prop) (h : ∀ᶠ y in 𝓝 x, P y) : P x :=
 -- QUOTE.
 
 /- TEXT:
-Then a more subtle requirement is that, for any predicate ``P : X → Prop`` and any ``x``, if ``P y`` holds for ``y`` close
-to ``x`` then for ``y`` close to ``x`` and ``z`` close to ``y``, ``P z`` holds. More precisely we have:
+然后一个更微妙的要求是，对于任何谓词``P : X → Prop``以及任何``x``，如果``P y``对于接近``x``的``y``成立，那么对于接近``x``的``y``以及接近``y``的``z``，``P z``也成立。更确切地说，我们有：
 BOTH: -/
 -- QUOTE:
 example {P : X → Prop} {x : X} (h : ∀ᶠ y in 𝓝 x, P y) : ∀ᶠ y in 𝓝 x, ∀ᶠ z in 𝓝 y, P z :=
@@ -129,11 +98,7 @@ example {P : X → Prop} {x : X} (h : ∀ᶠ y in 𝓝 x, P y) : ∀ᶠ y in �
 -- QUOTE.
 
 /- TEXT:
-Those two results characterize the functions ``X → Filter X`` that are neighborhood functions for a topological space
-structure on ``X``. There is a still a function ``TopologicalSpace.mkOfNhds : (X → Filter X) → TopologicalSpace X``
-but it will give back its input as a neighborhood function only if it satisfies the above two constraints.
-More precisely we have a lemma ``TopologicalSpace.nhds_mkOfNhds`` saying that in a different way and our
-next exercise deduces this different way from how we stated it above.
+这两个结果描述了对于集合 X 上的拓扑空间结构而言，函数``X → Filter X``成为邻域函数的特征。仍然存在一个函数``TopologicalSpace.mkOfNhds : (X → Filter X) → TopologicalSpace X``，但只有当输入满足上述两个约束条件时，它才会将其作为邻域函数返回。更确切地说，我们有一个引理``TopologicalSpace.nhds_mkOfNhds``，以另一种方式说明了这一点，而我们的下一个练习将从上述表述方式推导出这种不同的表述方式。
 BOTH: -/
 #check TopologicalSpace.mkOfNhds
 
@@ -160,30 +125,15 @@ end
 
 -- BOTH.
 /- TEXT:
-Note that ``TopologicalSpace.mkOfNhds`` is not so frequently used, but it still good to know in what
-precise sense the neighborhood filters is all there is in a topological space structure.
+请注意，``TopologicalSpace.mkOfNhds`` 并不经常使用，但了解拓扑空间结构中邻域滤子的精确含义仍然是很有好处的。
 
-The next thing to know in order to efficiently use topological spaces in Mathlib is that we use a lot
-of formal properties of ``TopologicalSpace : Type u → Type u``. From a purely mathematical point of view,
-those formal properties are a very clean way to explain how topological spaces solve issues that metric spaces
-have. From this point of view, the issues solved by topological spaces is that metric spaces enjoy very
-little functoriality, and have very bad categorical properties in general. This comes on top of the fact
-already discussed that metric spaces contain a lot of geometrical information that is not topologically relevant.
+要在 Mathlib 中高效地使用拓扑空间，接下来需要了解的是，我们大量使用了 ``TopologicalSpace : Type u → Type u`` 的形式属性。从纯粹的数学角度来看，这些形式属性是解释拓扑空间如何解决度量空间存在的问题的一种非常清晰的方式。从这个角度来看，拓扑空间解决的问题在于度量空间的函子性非常差，而且总体上具有非常糟糕的范畴性质。这还不包括前面已经讨论过的度量空间包含大量拓扑上无关的几何信息这一事实。
 
-Let us focus on functoriality first. A metric space structure can be induced on a subset or,
-equivalently, it can be pulled back by an injective map. But that's pretty much everything.
-They cannot be pulled back by general map or pushed forward, even by surjective maps.
+我们先关注函子性。度量空间结构可以诱导到子集上，或者等价地说，可以通过单射映射拉回。但也就仅此而已。它们不能通过一般的映射拉回，甚至不能通过满射映射推前。
 
-In particular there is no sensible distance to put on a quotient of a metric space or on an uncountable
-products of metric spaces. Consider for instance the type ``ℝ → ℝ``, seen as
-a product of copies of ``ℝ`` indexed by ``ℝ``. We would like to say that pointwise convergence of
-sequences of functions is a respectable notion of convergence. But there is no distance on
-``ℝ → ℝ`` that gives this notion of convergence. Relatedly, there is no distance ensuring that
-a map ``f : X → (ℝ → ℝ)`` is continuous if and only if ``fun x ↦ f x t`` is continuous for every ``t : ℝ``.
+特别是对于度量空间的商空间或不可数个度量空间的乘积，不存在合理的距离。例如，考虑类型``ℝ → ℝ``，将其视为由``ℝ``索引的``ℝ``的副本的乘积。我们希望说函数序列的逐点收敛是一种值得考虑的收敛概念。但在``ℝ → ℝ``上不存在能给出这种收敛概念距离。与此相关的是，不存在这样的距离，使得映射``f : X → (ℝ → ℝ)``是连续的当且仅当对于每个``t ： ℝ``，``fun x ↦ f x t``是连续的。
 
-We now review the data used to solve all those issues. First we can use any map ``f : X → Y`` to
-push or pull topologies from one side to the other. Those two operations form a Galois connection.
-
+现在我们来回顾一下用于解决所有这些问题的数据。首先，我们可以使用任何映射``f : X → Y``将拓扑从一侧推到另一侧或从另一侧拉到这一侧。这两个操作形成了一个伽罗瓦连接。
 BOTH: -/
 -- QUOTE:
 variable {X Y : Type*}
@@ -200,27 +150,16 @@ example (f : X → Y) (T_X : TopologicalSpace X) (T_Y : TopologicalSpace Y) :
 -- QUOTE.
 
 /- TEXT:
-Those operations are compactible with composition of functions.
-As usual, pushing forward is covariant and pulling back is contravariant, see ``coinduced_compose`` and ``induced_compose``.
-On paper we will use notations :math:`f_*T` for ``TopologicalSpace.coinduced f T`` and
-:math:`f^*T` for ``TopologicalSpace.induced f T``.
+这些操作与函数的复合兼容。
+通常，前推是协变的，后拉是逆变的，参见``coinduced_compose``和``induced_compose``。
+在纸上，我们将使用记号 :math:`f_*T` 表示 ``TopologicalSpace.coinduced f T`` ，使用记号 :math:`f^*T` 表示 ``TopologicalSpace.induced f T`` 。
 BOTH: -/
 #check coinduced_compose
 
 #check induced_compose
 
 /- TEXT:
-
-Then the next big piece is a complete lattice structure on ``TopologicalSpace X``
-for any given structure. If you think of topologies as being primarily the data of open sets then you expect
-the order relation on ``TopologicalSpace X`` to come from ``Set (Set X)``, i.e. you expect ``t ≤ t'``
-if a set ``u`` is open for ``t'`` as soon as it is open for ``t``. However we already know that Mathlib focuses
-on neighborhoods more than open sets so, for any ``x : X`` we want the map from topological spaces to neighborhoods
-``fun T : TopologicalSpace X ↦ @nhds X T x`` to be order preserving.
-And we know the order relation on ``Filter X`` is designed to ensure an order
-preserving ``principal : Set X → Filter X``, allowing to see filters as generalized sets.
-So the order relation we do use on  ``TopologicalSpace X`` is opposite to the one coming from ``Set (Set X)``.
-
+接下来的一个重要部分是在给定结构下对``拓扑空间 X``建立一个完整的格结构。如果您认为拓扑主要是开集的数据，那么您会期望``拓扑空间 X``上的序关系来自``Set (Set X)``，即您期望``t ≤ t'``当且仅当对于 ``t'`` 中的开集 ``u``，它在 ``t`` 中也是开集。然而，我们已经知道 Mathlib 更侧重于邻域而非开集，因此对于任何``x ： X``，我们希望从拓扑空间到邻域的映射``fun T ： TopologicalSpace X ↦ @nhds X T x``是保序的。而且我们知道``Filter X``上的序关系是为确保``principal : Set X → Filter X``保序而设计的，从而可以将滤子视为广义集合。所以我们在``TopologicalSpace X``上使用的序关系与来自``Set (Set X)``的序关系是相反的。
 BOTH: -/
 -- QUOTE:
 example {T T' : TopologicalSpace X} : T ≤ T' ↔ ∀ s, T'.IsOpen s → T.IsOpen s :=
@@ -229,7 +168,7 @@ example {T T' : TopologicalSpace X} : T ≤ T' ↔ ∀ s, T'.IsOpen s → T.IsOp
 
 /- TEXT:
 
-Now we can recover continuity by combining the push-forward (or pull-back) operation with the order relation.
+现在，我们可以通过将推进（或拉回）操作与序关系相结合来恢复连续性。
 
 BOTH: -/
 -- QUOTE:
@@ -239,10 +178,7 @@ example (T_X : TopologicalSpace X) (T_Y : TopologicalSpace Y) (f : X → Y) :
 -- QUOTE.
 
 /- TEXT:
-With this definition and the compatibility of push-forward and composition, we
-get for free the universal property that, for any topological space :math:`Z`,
-a function :math:`g : Y → Z` is continuous for the topology :math:`f_*T_X` if and only if
-:math:`g ∘ f` is continuous.
+有了这个定义以及前推和复合的兼容性，我们自然地得到了这样一个通用性质：对于任何拓扑空间 :math:`Z` ，函数 :math:`g : Y → Z` 对于拓扑 ：math:`f_*T_X` 是连续的，当且仅当 :math:`g ∘ f` 是连续的。
 
 .. math::
   g \text{ continuous } &⇔ g_*(f_*T_X) ≤ T_Z \\
@@ -260,14 +196,9 @@ example {Z : Type*} (f : X → Y) (T_X : TopologicalSpace X) (T_Z : TopologicalS
 -- QUOTE.
 
 /- TEXT:
-So we already get quotient topologies (using the projection map as ``f``). This wasn't using that
-``TopologicalSpace X`` is a complete lattice for all ``X``. Let's now see how all this structure
-proves the existence of the product topology by abstract non-sense.
-We considered the case of ``ℝ → ℝ`` above, but let's now consider the general case of ``Π i, X i`` for
-some ``ι : Type*`` and ``X : ι → Type*``. We want, for any topological space ``Z`` and any function
-``f : Z → Π i, X i``, that ``f`` is continuous if and only if ``(fun x ↦ x i) ∘ f`` is continuous for all ``i``.
-Let us explore that constraint "on paper" using notation :math:`p_i` for the projection
-``(fun (x : Π i, X i) ↦ x i)``:
+因此，我们已经得到了商拓扑（使用投影映射作为``f``）。这并没有用到对于所有``X``，``TopologicalSpace X``都是一个完备格这一事实。现在让我们看看所有这些结构如何通过抽象的废话证明积拓扑的存在性。
+我们上面考虑了``ℝ → ℝ``的情况，但现在让我们考虑一般情况``Π i, X i``，其中``ι : Type*``且``X ： ι → Type*``。我们希望对于任何拓扑空间``Z``以及任何函数``f ： Z → Π i， X i``，``f``是连续的当且仅当``(fun x ↦ x i) ∘ f``对于所有``i``都是连续的。
+让我们在纸上用符号``p_i``表示投影``(fun (x ： Π i， X i) ↦ x i)``来探究这个约束条件：
 
 .. math::
   (∀ i, p_i ∘ f \text{ continuous}) &⇔ ∀ i, (p_i ∘ f)_* T_Z ≤ T_{X_i} \\
@@ -275,7 +206,7 @@ Let us explore that constraint "on paper" using notation :math:`p_i` for the pro
   &⇔ ∀ i, f_* T_Z ≤ (p_i)^*T_{X_i}\\
   &⇔  f_* T_Z ≤ \inf \left[(p_i)^*T_{X_i}\right]
 
-So we see that what is the topology we want on ``Π i, X i``:
+因此我们看到，对于``Π i, X i``，我们想要的拓扑结构是什么：
 BOTH: -/
 -- QUOTE:
 example (ι : Type*) (X : ι → Type*) (T_X : ∀ i, TopologicalSpace (X i)) :
@@ -285,20 +216,15 @@ example (ι : Type*) (X : ι → Type*) (T_X : ∀ i, TopologicalSpace (X i)) :
 -- QUOTE.
 
 /- TEXT:
+这就结束了我们关于 Mathlib 的探讨，其如何认为拓扑空间通过成为更具函子性的理论与对于任何固定类型都具有完备格结构的特性，从而弥补度量空间理论的缺陷。
 
-This ends our tour of how Mathlib thinks that topological spaces fix defects of the theory of metric spaces
-by being a more functorial theory and having a complete lattice structure for any fixed type.
+分离性与可数性
+^^^^^^^^^^^^^
 
-Separation and countability
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We saw that the category of topological spaces have very nice properties. The price to pay for
-this is existence of rather pathological topological spaces.
-There are a number of assumptions you can make on a topological space to ensure its behavior
-is closer to what metric spaces do. The most important is ``T2Space``, also called "Hausdorff",
-that will ensure that limits are unique.
-A stronger separation property is ``T3Space`` that ensures in addition the `RegularSpace` property:
-each point has a basis of closed neighborhoods.
+我们看到拓扑空间范畴具有非常良好的性质。为此付出的代价是存在一些相当病态的拓扑空间。
+你可以对拓扑空间做出一些假设，以确保其行为更接近度量空间。其中最重要的是``T2 空间``，也称为“豪斯多夫空间”，它能确保极限是唯一的。
+更强的分离性质是``T3 空间``，它还确保了``正则空间``性质：每个点都有一个闭邻域基。
 
 BOTH: -/
 -- QUOTE:
@@ -312,8 +238,7 @@ example [TopologicalSpace X] [RegularSpace X] (a : X) :
 -- QUOTE.
 
 /- TEXT:
-Note that, in every topological space, each point has a basis of open neighborhood, by definition.
-
+请注意，根据定义，在每个拓扑空间中，每个点都有一个开邻域基。
 BOTH: -/
 -- QUOTE:
 example [TopologicalSpace X] {x : X} :
@@ -322,26 +247,15 @@ example [TopologicalSpace X] {x : X} :
 -- QUOTE.
 
 /- TEXT:
-Our main goal is now to prove the basic theorem which allows extension by continuity.
-From Bourbaki's general topology book, I.8.5, Theorem 1 (taking only the non-trivial implication):
+我们现在的主要目标是证明基本定理，该定理允许通过连续性进行延拓。从布尔巴基学派的《一般拓扑学》一书，第 I 卷第 8.5 节，定理 1（仅取非平凡的蕴含部分）：
 
-Let :math:`X` be a topological space, :math:`A` a dense subset of :math:`X`, :math:`f : A → Y`
-a continuous mapping of :math:`A` into a :math:`T_3` space :math:`Y`. If, for each :math:`x` in
-:math:`X`, :math:`f(y)` tends to a limit in :math:`Y` when :math:`y` tends to :math:`x`
-while remaining in :math:`A` then there exists a continuous extension :math:`φ` of :math:`f` to
-:math:`X`.
+设 :math:`X` 为拓扑空间，:math:`A` 是 :math:`X` 的一个稠密子集，:math:`f : A → Y` 是将 :math:`A` 映射到 :math:`T_3` 空间 :math:`Y` 的连续映射。若对于 :math:`X` 中的每个点 :math:`x` ，当 :math:`y` 趋近于 :math:`x` 且始终处于 :math:`A` 内时，:math:`f(y)` 在 :math:`Y` 中趋于一个极限，则存在 :math:`f` 在 :math:`X` 上的连续延拓 :math:`φ` 。
 
-Actually Mathlib contains a more general version of the above lemma, ``DenseInducing.continuousAt_extend``,
-but we'll stick to Bourbaki's version here.
+实际上，Mathlib 包含了上述引理的一个更通用的版本``DenseInducing.continuousAt_extend``，但在这里我们将遵循布尔巴基的版本。
 
-Remember that, given ``A : Set X``, ``↥A`` is the subtype associated to ``A``, and Lean will automatically
-insert that funny up arrow when needed. And the (inclusion) coercion map is ``(↑) : A → X``.
-The assumption "tends to :math:`x` while remaining in :math:`A`" corresponds to the pull-back filter
-``comap (↑) (𝓝 x)``.
+请记住，对于 ``A : Set X`` ，``↥A`` 是与 ``A`` 相关联的子类型，并且在需要时，Lean 会自动插入那个有趣的上箭头。而（包含）强制转换映射为 ``(↑) : A → X`` 。假设“趋向于 :math:`x` 且始终处于 :math:`A` 中”对应于拉回滤子 ``comap (↑) (𝓝 x)`` 。
 
-Let's first prove an auxiliary lemma, extracted to simplify the context
-(in particular we don't need Y to be a topological space here).
-
+我们首先证明一个辅助引理，将其提取出来以简化上下文（特别是这里我们不需要 Y 是拓扑空间）。
 BOTH: -/
 -- QUOTE:
 theorem aux {X Y A : Type*} [TopologicalSpace X] {c : A → X}
@@ -356,34 +270,29 @@ SOLUTIONS: -/
 -- QUOTE.
 
 /- TEXT:
-Let's now turn to the main proof of the extension by continuity theorem.
+现在让我们来证明连续性延拓定理的主要内容。
 
-When Lean needs a topology on ``↥A`` it will automatically use the induced topology.
-The only relevant lemma is
-``nhds_induced (↑) : ∀ a : ↥A, 𝓝 a = comap (↑) (𝓝 ↑a)``
-(this is actually a general lemma about induced topologies).
+当需要在 ``↥A`` 上定义拓扑时，Lean 会自动使用诱导拓扑。
+唯一相关的引理是
+``nhds_induced (↑) : ∀ a ： ↥A， 𝓝 a = comap (↑) (𝓝 ↑a)``
+（这实际上是一个关于诱导拓扑的一般引理）。
 
-The proof outline is:
+证明的大致思路是：
 
-The main assumption and the axiom of choice give a function ``φ`` such that
+主要假设和选择公理给出一个函数``φ``，使得
 ``∀ x, Tendsto f (comap (↑) (𝓝 x)) (𝓝 (φ x))``
-(because ``Y`` is Hausdorff, ``φ`` is entirely determined, but we won't need that until we try to
-prove that ``φ`` indeed extends ``f``).
+（因为``Y``是豪斯多夫空间，``φ``是完全确定的，但在我们试图证明``φ``确实扩展了``f``之前，我们不需要这一点）。
 
-Let's first prove ``φ`` is continuous. Fix any ``x : X``.
-Since ``Y`` is regular, it suffices to check that for every *closed* neighborhood
-``V'`` of ``φ x``, ``φ ⁻¹' V' ∈ 𝓝 x``.
-The limit assumption gives (through the auxiliary lemma above)
-some ``V ∈ 𝓝 x`` such ``IsOpen V ∧ (↑) ⁻¹' V ⊆ f ⁻¹' V'``.
-Since ``V ∈ 𝓝 x``, it suffices to prove ``V ⊆ φ ⁻¹' V'``, i.e.  ``∀ y ∈ V, φ y ∈ V'``.
-Let's fix ``y`` in ``V``. Because ``V`` is *open*, it is a neighborhood of ``y``.
-In particular ``(↑) ⁻¹' V ∈ comap (↑) (𝓝 y)`` and a fortiori ``f ⁻¹' V' ∈ comap (↑) (𝓝 y)``.
-In addition ``comap (↑) (𝓝 y) ≠ ⊥`` because ``A`` is dense.
-Because we know ``Tendsto f (comap (↑) (𝓝 y)) (𝓝 (φ y))`` this implies
-``φ y ∈ closure V'`` and, since ``V'`` is closed, we have proved ``φ y ∈ V'``.
+首先证明``φ``是连续的。固定任意的``x : X``。
+由于``Y``是正则的，只需检查对于``φ x``的每个**闭**邻域``V'``，``φ⁻¹' V' ∈ 𝓝 x``。
+极限假设（通过上面的辅助引理）给出了某个``V ∈ 𝓝 x``，使得``IsOpen V ∧ (↑)⁻¹' V ⊆ f⁻¹' V'``。
+由于``V ∈ 𝓝 x``，只需证明``V ⊆ φ⁻¹' V'``，即``∀ y ∈ V， φ y ∈ V'``。
+固定``V``中的``y``。因为``V``是**开**的，所以它是``y``的邻域。
+特别是``(↑)⁻¹' V ∈ comap (↑) (𝓝 y)``且更进一步``f⁻¹' V' ∈ comap (↑) (𝓝 y)``。
+此外，``comap (↑) (𝓝 y) ≠ ⊥``因为``A``是稠密的。
+因为我们知道``Tendsto f (comap (↑) (𝓝 y)) (𝓝 (φ y))``，这表明``φ y ∈ closure V'``，并且由于``V'``是闭的，我们已经证明了``φ y ∈ V'``。
 
-It remains to prove that ``φ`` extends ``f``. This is where the continuity of ``f`` enters the
-discussion, together with the fact that ``Y`` is Hausdorff.
+接下来要证明的是``φ``延拓了``f``。这里就要用到``f``的连续性以及``Y``是豪斯多夫空间这一事实。
 BOTH: -/
 -- QUOTE:
 example [TopologicalSpace X] [TopologicalSpace Y] [T3Space Y] {A : Set X}
@@ -418,10 +327,7 @@ SOLUTIONS: -/
 -- QUOTE.
 
 /- TEXT:
-In addition to separation property, the main kind of assumption you can make on a topological
-space to bring it closer to metric spaces is countability assumption. The main one is first countability
-asking that every point has a countable neighborhood basis. In particular this ensures that closure
-of sets can be understood using sequences.
+除了分离性之外，您还可以对拓扑空间做出的主要假设是可数性假设，以使其更接近度量空间。其中最主要的是第一可数性，即要求每个点都有一个可数的邻域基。特别是，这确保了集合的闭包可以通过序列来理解。
 
 BOTH: -/
 -- QUOTE:
@@ -432,18 +338,15 @@ example [TopologicalSpace X] [FirstCountableTopology X]
 -- QUOTE.
 
 /- TEXT:
-Compactness
-^^^^^^^^^^^
+紧致性
+^^^^^
 
-Let us now discuss how compactness is defined for topological spaces. As usual there are several ways
-to think about it and Mathlib goes for the filter version.
 
-We first need to define cluster points of filters. Given a filter ``F`` on a topological space ``X``,
-a point ``x : X`` is a cluster point of ``F`` if ``F``, seen as a generalized set, has non-empty intersection
-with the generalized set of points that are close to ``x``.
+现在让我们来讨论一下拓扑空间的紧致性是如何定义的。和往常一样，对此有多种思考方式，而 Mathlib 采用的是滤子版本。
 
-Then we can say that a set ``s`` is compact if every nonempty generalized set ``F`` contained in ``s``,
-i.e. such that ``F ≤ 𝓟 s``, has a cluster point in ``s``.
+我们首先需要定义滤子的聚点。给定拓扑空间 ``X`` 上的一个滤子 ``F`` ，若将 ``F`` 视为广义集合，则点 ``x : X`` 是 ``F`` 的聚点，当且仅当 ``F`` 与广义集合中所有接近 ``x`` 的点的集合有非空交集。
+
+那么我们就可以说，集合 ``s`` 是紧致的，当且仅当包含于 ``s`` 中的每一个非空广义集合 ``F`` ，即满足 ``F ≤ 𝓟 s`` 的集合，都在 ``s`` 中有一个聚点。
 
 BOTH: -/
 -- QUOTE:
@@ -458,12 +361,7 @@ example {s : Set X} :
 -- QUOTE.
 
 /- TEXT:
-For instance if ``F`` is ``map u atTop``, the image under ``u : ℕ → X`` of ``atTop``, the generalized set
-of very large natural numbers, then the assumption ``F ≤ 𝓟 s`` means that ``u n`` belongs to ``s`` for ``n``
-large enough. Saying that ``x`` is a cluster point of ``map u atTop`` says the image of very large numbers
-intersects the set of points that are close to ``x``. In case ``𝓝 x`` has a countable basis, we can
-interpret this as saying that ``u`` has a subsequence converging to ``x``, and we get back what compactness
-looks like in metric spaces.
+例如，如果 ``F`` 是 ``map u atTop``，即 ``u ： ℕ → X`` 在 ``atTop`` 下的像，其中 ``atTop`` 是非常大的自然数的广义集合，那么假设 ``F ≤ 𝓟 s`` 意味着对于足够大的 ``n``，``u n`` 属于 ``s``。说 ``x`` 是 ``map u atTop`` 的聚点意味着非常大的数的像与接近 ``x`` 的点的集合相交。如果 ``𝓝 x`` 有一个可数基，我们可以将其解释为说 ``u`` 有一个子序列收敛于 ``x``，这样我们就得到了度量空间中紧致性的样子。
 BOTH: -/
 -- QUOTE:
 example [FirstCountableTopology X] {s : Set X} {u : ℕ → X} (hs : IsCompact s)
@@ -472,8 +370,7 @@ example [FirstCountableTopology X] {s : Set X} {u : ℕ → X} (hs : IsCompact s
 -- QUOTE.
 
 /- TEXT:
-Cluster points behave nicely with continuous functions.
-
+聚点与连续函数的性质相容。
 BOTH: -/
 -- QUOTE:
 variable [TopologicalSpace Y]
@@ -484,9 +381,7 @@ example {x : X} {F : Filter X} {G : Filter Y} (H : ClusterPt x F) {f : X → Y}
 -- QUOTE.
 
 /- TEXT:
-As an exercise, we will prove that the image of a compact set under a continuous map is
-compact. In addition to what we saw already, you should use ``Filter.push_pull`` and
-``NeBot.of_map``.
+作为练习，我们将证明连续映射下的紧集的像是紧集。除了我们已经看到的内容外，您还应该使用``Filter.push_pull``和``NeBot.of_map``。
 BOTH: -/
 -- QUOTE:
 -- EXAMPLES:
@@ -515,9 +410,7 @@ example [TopologicalSpace Y] {f : X → Y} (hf : Continuous f) {s : Set X} (hs :
   exact inf_le_right
 
 /- TEXT:
-One can also express compactness in terms of open covers: ``s`` is compact if every family of open sets that
-cover ``s`` has a finite covering sub-family.
-
+也可以用开覆盖来表述紧性：``s``是紧的，当且仅当覆盖``s``的每一个开集族都有一个有限的覆盖子族。
 BOTH: -/
 -- QUOTE:
 example {ι : Type*} {s : Set X} (hs : IsCompact s) (U : ι → Set X) (hUo : ∀ i, IsOpen (U i))


### PR DESCRIPTION
- 修改了 `C10_Topology/S01_Filters.lean` 文件。
- 修改了 `C10_Topology/C10_Topology.rst` 文档。

- Topology #10

- direct image查阅资料并未找到广泛接受的翻译，目前初步拟定为直接像，望专业人士指正
- 如We can do better by noting that一句，仍在斟酌忠实原文和易读之间平衡，望专业人士指教
- 尚未熟练翻译流程，参考规范“将原文注释掉后，在下方空一行再进行翻译。”
- 但参考本仓库中其余已翻译内容，似乎以上方式并非兼用

- 使用有道ai翻译粗翻后人工粗校，边学习对于本人较为陌生的领域边修正，还望海涵
- 参考OlingCat.trans-box，简单编写vscode插件，使用快捷键正则表达式进行错误格式的快速替换
- 接下来的方向，希望学习trans-box使用ai翻译api与解析文本格式实现半自动翻译

- 尚未提取术语表